### PR TITLE
Participant and entry date sort order not working as expected

### DIFF
--- a/admin/entries.admin.php
+++ b/admin/entries.admin.php
@@ -385,7 +385,7 @@ if ($action != "print") { ?>
         <td><?php echo $entry_style_display; ?></td>
         <td class="hidden-xs"><?php echo $entry_brewer_display; ?></td>
         <td class="hidden-xs hidden-sm hidden-md hidden-print"><?php echo $brewer_info[8] ; ?></td>
-        <td class="hidden-xs hidden-sm hidden-md hidden-print"><?php echo $entry_updated_display; ?></td>
+        <td class="hidden-xs hidden-sm hidden-md hidden-print" data-sort='<?php echo strtotime($row_log['brewUpdated'])?>'><?php echo $entry_updated_display; ?></td>
         <td class="hidden-xs"><?php echo $entry_paid_display; ?></td>
         <td class="hidden-xs"><?php echo $entry_received_display; ?></td>
         <td><?php echo $entry_box_num_display; ?></td>

--- a/admin/participants.admin.php
+++ b/admin/participants.admin.php
@@ -336,11 +336,10 @@ do {
 	}
 	
 	
-	$output_datatables_body .= "<td class=\"".$output_hide_print."\">".date_created($row_brewer['uid'],$_SESSION['prefsDateFormat'],$_SESSION['prefsTimeFormat'],$_SESSION['prefsTimeZone'],$dbTable)."</td>";
-	
+	$output_datatables_body .= "<td class=\"".$output_hide_print."\" data-sort='".date_created_timestamp($row_brewer['uid'],$dbTable)."'>".date_created($row_brewer['uid'],$_SESSION['prefsDateFormat'],$_SESSION['prefsTimeFormat'],$_SESSION['prefsTimeZone'],$dbTable)."</td>";
 	if (($action != "print") && ($dbTable == "default")) { 
 	
-	
+//	var_dump($row_brewer);exit;
 	// build_action_link($icon,$base_url,$section,$go,$action,$filter,$id,$dbTable,$alt_title) {
 		
 		$output_datatables_add_link = build_action_link("fa-beer",$base_url,"brew","entries","add",$row_brewer['uid'],"default","default","Add an entry for ".$row_brewer['brewerFirstName']." ".$row_brewer['brewerLastName']);

--- a/admin/participants.admin.php
+++ b/admin/participants.admin.php
@@ -339,7 +339,6 @@ do {
 	$output_datatables_body .= "<td class=\"".$output_hide_print."\" data-sort='".date_created_timestamp($row_brewer['uid'],$dbTable)."'>".date_created($row_brewer['uid'],$_SESSION['prefsDateFormat'],$_SESSION['prefsTimeFormat'],$_SESSION['prefsTimeZone'],$dbTable)."</td>";
 	if (($action != "print") && ($dbTable == "default")) { 
 	
-//	var_dump($row_brewer);exit;
 	// build_action_link($icon,$base_url,$section,$go,$action,$filter,$id,$dbTable,$alt_title) {
 		
 		$output_datatables_add_link = build_action_link("fa-beer",$base_url,"brew","entries","add",$row_brewer['uid'],"default","default","Add an entry for ".$row_brewer['brewerFirstName']." ".$row_brewer['brewerLastName']);

--- a/lib/admin.lib.php
+++ b/lib/admin.lib.php
@@ -861,6 +861,30 @@ function date_created($uid,$date_format,$time_format,$timezone,$dbTable) {
 	return $result;
 }
 
+function date_created_timestamp($uid,$dbTable) {
+	include(CONFIG.'config.php');	
+	mysql_select_db($database, $brewing);
+	if ($dbTable != "default") $dbTable = $dbTable; else $dbTable = $prefix."users";
+	
+        $result = '';
+	$result1 = mysql_query(sprintf("SHOW COLUMNS FROM %s LIKE 'userCreated'",$dbTable));
+	$exists = (mysql_num_rows($result1))?TRUE:FALSE;
+	
+	if ($exists) {
+	
+		$query_user = sprintf("SELECT unix_timestamp(userCreated) AS userCreated FROM %s WHERE id = '%s'",$dbTable,$uid);
+		$user = mysql_query($query_user, $brewing) or die(mysql_error());
+		$row_user = mysql_fetch_assoc($user);
+		$totalRows_user = mysql_num_rows($user);
+		
+		if ($totalRows_user == 1) {
+			$result = $row_user['userCreated'];
+		}
+		
+	}
+	return $result;
+}
+
 function user_info($uid) {
 	include(CONFIG.'config.php');	
 	mysql_select_db($database, $brewing);


### PR DESCRIPTION
Currently the sort order for entries and participants doesn't work as expected as a basic numerical sort is being done on the date portion ignoring month and year. Using a timestamp and the data-sort attribute ensures dates are sorted in date order not numerical sort order on juts the first portion of the date