### PR TITLE
sql statement missing a comma

### DIFF
--- a/includes/process/process_brewer.inc.php
+++ b/includes/process/process_brewer.inc.php
@@ -278,7 +278,7 @@ if (((isset($_SESSION['loginUsername'])) && (isset($_SESSION['userLevel']))) || 
 				  
 				  brewerDropOff,
 				  brewerJudgeExp,
-				  brewerJudgeNotes
+				  brewerJudgeNotes,
 				  brewerStaff
 				) VALUES (
 				%s, %s, %s, %s, %s, 


### PR DESCRIPTION
Was producing an invalid SQL statement during new-site setup.