### PR TITLE
Fix fatal error [] operator is not supported for strings.

### DIFF
--- a/sections/brew.sec.php
+++ b/sections/brew.sec.php
@@ -122,7 +122,9 @@ $adminUserAddDisable = FALSE;
 
 if (($_SESSION['userLevel'] == 2) && ($action == "edit")) {
 
-	$user_entries = "";
+
+	// Fix fatal error when using [] operator on strings
+	$user_entries = [];
 
 	// Check whether user is "authorized" to edit the entry in DB
 	$query_brews = sprintf("SELECT id FROM $brewing_db_table WHERE brewBrewerId = '%s'", $_SESSION['user_id']);


### PR DESCRIPTION
In newer versions of php using [] to add an array element to something that is defined as a string is a fatal error.