### PR TITLE
Fix error in statement that was preventing creation of a new deployment

### DIFF
--- a/includes/process/process_brewer.inc.php
+++ b/includes/process/process_brewer.inc.php
@@ -388,7 +388,7 @@ if ((isset($_SERVER['HTTP_REFERER'])) && (((isset($_SESSION['loginUsername'])) &
 				%s, %s, %s, %s, %s,
 				%s, %s, %s, %s, %s,
 				%s, %s, %s, %s, %s
-				%s. %s)",
+				%s, %s)",
 							   GetSQLValueString($_POST['uid'], "int"),
 							   GetSQLValueString($first_name, "text"),
 							   GetSQLValueString($last_name, "text"),


### PR DESCRIPTION
I was attempting to create a new deployment of BCOE&M but the error in this SQL statement prevented me from completing setup.