### PR TITLE
Revert "Add "Michigan Mead Coalition" to $club_array"

### DIFF
--- a/includes/constants.inc.php
+++ b/includes/constants.inc.php
@@ -1436,7 +1436,6 @@ $club_array = array(
     "Miami Beach Home Brew",
     "Miami County Brewing Club",
     "Michiana Extract &amp; Grain Association (MEGA)",
-    "Michigan Mead Coalition:,
     "Michigan Occasional Brewers (MOB)",
     "Mid Columbia Zymurgy Association",
     "Mid Michigan Ale and Lager Team (MMALT)",


### PR DESCRIPTION
Reverts geoffhumphrey/brewcompetitiononlineentry#1237;
Included code was malformed, introducing an error.