### PR TITLE
Update for PHP 8

### DIFF
--- a/admin/upload_mod.admin.php
+++ b/admin/upload_mod.admin.php
@@ -6,7 +6,7 @@ $imageSrc = $base_url."images/";
 
 $fileCornfirm = "default";
 if (isset($_GET['fileConfirm'])) {
-  $fileConfirm = (get_magic_quotes_gpc()) ? $_GET['fileConfirm'] : addslashes($_GET['fileConfirm']);
+  $fileConfirm = addslashes($_GET['fileConfirm']);
 }
 
 //Mmaximum file size.

--- a/admin/upload_mod.admin.php
+++ b/admin/upload_mod.admin.php
@@ -4,7 +4,7 @@ require(CONFIG.'bootstrap.php');
 
 $imageSrc = $base_url."images/";
 
-$fileCornfirm = "default";
+$fileConfirm = "default";
 if (isset($_GET['fileConfirm'])) {
   $fileConfirm = addslashes($_GET['fileConfirm']);
 }

--- a/ajax/save.ajax.php
+++ b/ajax/save.ajax.php
@@ -18,22 +18,22 @@ require(CONFIG.'bootstrap.php');
 // For use in ajax URLS
 $rid1 = "default";
 if (isset($_GET['rid1'])) {
-  $rid1 = (get_magic_quotes_gpc()) ? $_GET['rid1'] : addslashes($_GET['rid1']);
+  $rid1 = addslashes($_GET['rid1']);
 }
 
 $rid2 = "default";
 if (isset($_GET['rid2'])) {
-  $rid2 = (get_magic_quotes_gpc()) ? $_GET['rid2'] : addslashes($_GET['rid2']);
+  $rid2 = addslashes($_GET['rid2']);
 }
 
 $rid3 = "default";
 if (isset($_GET['rid3'])) {
-  $rid3 = (get_magic_quotes_gpc()) ? $_GET['rid3'] : addslashes($_GET['rid3']);
+  $rid3 = addslashes($_GET['rid3']);
 }
 
 $rid4 = "default";
 if (isset($_GET['rid4'])) {
-  $rid4 = (get_magic_quotes_gpc()) ? $_GET['rid4'] : addslashes($_GET['rid4']);
+  $rid4 = addslashes($_GET['rid4']);
 }
 
 $return_json = array();

--- a/includes/db/mods.db.php
+++ b/includes/db/mods.db.php
@@ -25,7 +25,10 @@ $totalRows_mods = mysqli_num_rows($mods);
 //echo "<p>".$query_mods."</p>";
 
 if ($go != "mods") {
-	do { $mods_display[] = $row_mods['id']; } while ($row_mods = mysqli_fetch_assoc($mods));
+	$mods_display = array();
+	while ($row_mods = mysqli_fetch_assoc($mods)) {
+		$mods_display[] = $row_mods['id'];
+	}
 }
 
 //print_r($mods_display);

--- a/includes/logincheck.inc.php
+++ b/includes/logincheck.inc.php
@@ -16,7 +16,7 @@ require(LIB.'common.lib.php');
 
 $section = "default";
 if (isset($_GET['section'])) {
-  $section = (get_magic_quotes_gpc()) ? $_GET['section'] : addslashes($_GET['section']);
+  $section = addslashes($_GET['section']);
 }
 
 header('Expires: Sat, 26 Jul 1997 05:00:00 GMT'); 

--- a/includes/url_variables.inc.php
+++ b/includes/url_variables.inc.php
@@ -7,118 +7,118 @@ Checked Single
 
 $id = "default";
 if (isset($_GET['id'])) {
-  $id = (get_magic_quotes_gpc()) ? $_GET['id'] : addslashes($_GET['id']);
+  $id = addslashes($_GET['id']);
 }
 
 $uid = "default";
 if (isset($_GET['uid'])) {
-  $uid = (get_magic_quotes_gpc()) ? $_GET['uid'] : addslashes($_GET['uid']);
+  $uid = addslashes($_GET['uid']);
 }
 
 $section = "default";
 if (isset($_GET['section'])) {
-  $section = (get_magic_quotes_gpc()) ? $_GET['section'] : addslashes($_GET['section']);
+  $section = addslashes($_GET['section']);
 }
 
 $action = "default";
 if (isset($_GET['action'])) {
-  $action = (get_magic_quotes_gpc()) ? $_GET['action'] : addslashes($_GET['action']);
+  $action = addslashes($_GET['action']);
 }
 
 $msg = "default";
 if (isset($_GET['msg'])) {
-  $msg = (get_magic_quotes_gpc()) ? $_GET['msg'] : addslashes($_GET['msg']);
+  $msg = addslashes($_GET['msg']);
 }
 
 $go = "default";
 if (isset($_GET['go'])) {
-  $go = (get_magic_quotes_gpc()) ? $_GET['go'] : addslashes($_GET['go']);
+  $go = addslashes($_GET['go']);
 }
 
 $username = "default";
 if (isset($_GET['username'])) {
-  $username = (get_magic_quotes_gpc()) ? $_GET['username'] : addslashes($_GET['username']);
+  $username = addslashes($_GET['username']);
 }
 
 $dbTable = "default";
 if (isset($_GET['dbTable'])) {
-  $dbTable = (get_magic_quotes_gpc()) ? $_GET['dbTable'] : addslashes($_GET['dbTable']);
+  $dbTable = addslashes($_GET['dbTable']);
 }
 
 $filter = "default";
 if (isset($_GET['filter'])) {
-  $filter = (get_magic_quotes_gpc()) ? $_GET['filter'] : addslashes($_GET['filter']);
+  $filter = addslashes($_GET['filter']);
 }
 
 $bid = "default";
 if (isset($_GET['bid'])) {
-  $bid = (get_magic_quotes_gpc()) ? $_GET['bid'] : addslashes($_GET['bid']);
+  $bid = addslashes($_GET['bid']);
 }
 
 $view = "default";
 if (isset($_GET['view'])) {
-  $view = (get_magic_quotes_gpc()) ? $_GET['view'] : addslashes($_GET['view']);
+  $view = addslashes($_GET['view']);
 }
 
 // ------------------ Token for authorized password changes ------------------
 $token = "default";
 if (isset($_GET['token'])) {
-  $token = (get_magic_quotes_gpc()) ? $_GET['token'] : addslashes($_GET['token']);
+  $token = addslashes($_GET['token']);
 }
 
 // ------------------ Only apply to print functions ------------------
 $tb = "default";
 if (isset($_GET['tb'])) {
-  $tb = (get_magic_quotes_gpc()) ? $_GET['tb'] : addslashes($_GET['tb']);
+  $tb = addslashes($_GET['tb']);
 }
 
 $psort = "default";
 if (isset($_GET['psort'])) {
-  $psort = (get_magic_quotes_gpc()) ? $_GET['psort'] : addslashes($_GET['psort']);
+  $psort = addslashes($_GET['psort']);
 }
 
 // ------------------ Only applies to process funtions ------------------
 $limit = "999999";
 if (isset($_GET['limit'])) {
-  $limit = (get_magic_quotes_gpc()) ? $_GET['limit'] : addslashes($_GET['limit']);
+  $limit = addslashes($_GET['limit']);
 }
 
 // ------------------ Only applies to function utilized in the /includes/data_cleanup.inc.php file ------------------
 $purge = "default";
 if (isset($_GET['purge'])) {
-  $purge = (get_magic_quotes_gpc()) ? $_GET['purge'] : addslashes($_GET['purge']);
+  $purge = addslashes($_GET['purge']);
 }
 
 // ------------------ The following only apply to printing of specific location and rounds in admin/default.admin.php ------------------
 $round = "default";
 if (isset($_GET['round'])) {
-  $round = (get_magic_quotes_gpc()) ? $_GET['round'] : addslashes($_GET['round']);
+  $round = addslashes($_GET['round']);
 }
 
 $location = "default";
 if (isset($_GET['location'])) {
-  $location = (get_magic_quotes_gpc()) ? $_GET['location'] : addslashes($_GET['location']);
+  $location = addslashes($_GET['location']);
 }
 
 // ------------------ Apparently unused ------------------
 $inserted = "default";
 if (isset($_GET['inserted'])) {
-  $inserted = (get_magic_quotes_gpc()) ? $_GET['inserted'] : addslashes($_GET['inserted']);
+  $inserted = addslashes($_GET['inserted']);
 }
 
 $dir = "ASC";
 if (isset($_GET['dir'])) {
-  $dir = (get_magic_quotes_gpc()) ? $_GET['dir'] : addslashes($_GET['dir']);
+  $dir = addslashes($_GET['dir']);
 }
 
 $pg = "default";
 if (isset($_GET['pg'])) {
-  $pg = (get_magic_quotes_gpc()) ? $_GET['pg'] : addslashes($_GET['pg']);
+  $pg = addslashes($_GET['pg']);
 }
 
 $sort = "brewCategorySort, brewSubCategory, brewBrewerLastName";
 if (isset($_GET['sort'])) {
-  $sort = (get_magic_quotes_gpc()) ? $_GET['sort'] : addslashes($_GET['sort']);
+  $sort = addslashes($_GET['sort']);
 }
 
 ?>

--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -423,7 +423,7 @@ if ($v == "milliliters") { // fluid ounces to milliliters
 }
 
 function GetSQLValueString($theValue, $theType, $theDefinedValue = "", $theNotDefinedValue = "")  {
-	$theValue = (!get_magic_quotes_gpc()) ? addslashes($theValue) : $theValue;
+	$theValue = addslashes($theValue);
 
 	require (INCLUDES.'scrubber.inc.php');
 


### PR DESCRIPTION
PHP 8 deprecated & removed `get_magic_quotes_gpc()`. This function has returned FALSE since PHP 5.4 so there is no real compatibility concern as the project is developed for PHP 7.3+. Also includes a small fix for PHP warning and one typo correction.