### PR TITLE
Update the name of QUAFF to be simply QUAFF

### DIFF
--- a/includes/constants.inc.php
+++ b/includes/constants.inc.php
@@ -1856,7 +1856,7 @@ $club_array = array(
     "Purgatory SOBs",
     "Puyallup Brew Crew",
     "Q and Q Brewers Guild",
-    "QUAFF (Quality Ale and Fermentation Fraternity)",
+    "QUAFF",
     "Queen City Homebrew Club",
     "Queers Makin' Beers",
     "Quick's Brew Club",


### PR DESCRIPTION
Leadership of QUAFF could like to change the name of the club from "QUAFF (Quality Ale and Fermentation Fraternity)" to just "QUAFF".