### PR TITLE
Update constants.inc.php - Add Panomaju

### DIFF
--- a/includes/constants.inc.php
+++ b/includes/constants.inc.php
@@ -1788,6 +1788,7 @@ $club_array = array(
     "Palm Beach Draughtsmen",
     "Palmetto State Brewers",
     "Palo Brew Crew",
+    "Panomaju",
     "Parker Hop-Aholics",
     "Parkside Homebrew Club",
     "PartTimeBrewers",


### PR DESCRIPTION
Heya,

Panomaju (https://www.instagram.com/panomaju_official/) the finnish national country team would like to be added to the clubs list. Panomaju has been winning competitions across Europe and would find it easier to mark things up with their club added to the list.