### PR TITLE
Add `Homebrew Collab (Bristol)` to the list of clubs

### DIFF
--- a/includes/constants.inc.php
+++ b/includes/constants.inc.php
@@ -1177,6 +1177,7 @@ $club_array = array(
     "Homebrew Battleground Brewers",
     "Homebrew Club [WA]",
     "Homebrew Club At Virginia Tech",
+    "Homebrew Collab (Bristol)",
     "Homebrew Connection",
     "Homebrew Hawaii",
     "Homebrew Heroes",


### PR DESCRIPTION
Adding our club to the constants list so people don't have to type it in and potentially get it in wrong. 