### PR TITLE
Add auto_increment to brewing id column

### DIFF
--- a/sql/bcoem_baseline_2.7.X.sql
+++ b/sql/bcoem_baseline_2.7.X.sql
@@ -164,7 +164,7 @@ INSERT INTO `baseline_brewer` (`id`, `uid`, `brewerFirstName`, `brewerLastName`,
 
 DROP TABLE IF EXISTS `baseline_brewing`;
 CREATE TABLE `baseline_brewing` (
-  `id` int(11) NOT NULL,
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `brewName` varchar(250) DEFAULT NULL,
   `brewStyle` varchar(250) DEFAULT NULL,
   `brewCategory` varchar(4) DEFAULT NULL,


### PR DESCRIPTION
Adding a second entry was silently failing, referring to SQL dumps of years gone by, the id key had AUTO_INCREMENT. 

Resolves https://github.com/geoffhumphrey/brewcompetitiononlineentry/issues/1572

