### PR TITLE
Fix session clearing on multiple-tab sessions.

### DIFF
--- a/includes/constants_post_lang.inc.php
+++ b/includes/constants_post_lang.inc.php
@@ -12,18 +12,12 @@ if ((TESTING) || (DEBUG)) {
 if (DEBUG) include (DEBUGGING.'query_count_begin.debug.php');
 
 /**
- * Generate a CSRF token on every page load.
- * This will be used to prevent cross-site request forgeries
- * when processing form data.
- * First check for php 7 compatible random_bytes.
- * If not, use mcrypt_create_iv (deprecated in php 7.1 removed in 7.2)
- * If that's not available, default to openssl_random_pseudo_bytes.
+ * Ensure a CSRF token exists for form processing.
+ * Keep the current token for normal page loads so open forms in other tabs
+ * remain valid. Rotate only on explicit auth transitions.
  */
 
-unset($_SESSION['user_session_token']);
-if (function_exists('random_bytes')) $_SESSION['user_session_token'] = bin2hex(random_bytes(32));
-elseif (function_exists('mcrypt_create_iv')) $_SESSION['user_session_token'] = bin2hex(mcrypt_create_iv(32,MCRYPT_DEV_URANDOM));
-else $_SESSION['user_session_token'] = bin2hex(openssl_random_pseudo_bytes(32));
+csrf_token_generate(false);
 
 // Bootstrap layout containers
 if (($section == "admin") || ($view == "admin")) {

--- a/includes/logincheck.inc.php
+++ b/includes/logincheck.inc.php
@@ -91,6 +91,9 @@ if ($check == 1) {
 	
 	// Register the session variable
 	$_SESSION['loginUsername'] = $loginUsername;
+
+	// Rotate CSRF token on successful login
+	csrf_token_generate(true);
 	
 	// Set the relocation variables
 	if ($section == "update") $location = $base_url."update.php";

--- a/includes/process/process_users_register.inc.php
+++ b/includes/process/process_users_register.inc.php
@@ -405,6 +405,7 @@ if (isset($_SERVER['HTTP_REFERER'])) {
 					
 					unset($_SESSION['user_info'.$prefix_session]);
 					$_SESSION['loginUsername'] = $username;
+					csrf_token_generate(true);
 					$redirect = $base_url."index.php?section=list&msg=7";
 					$redirect = prep_redirect_link($redirect);
 					$redirect_go_to = sprintf("Location: %s", $redirect);			

--- a/includes/process/process_users_setup.inc.php
+++ b/includes/process/process_users_setup.inc.php
@@ -68,6 +68,7 @@ if ((isset($_SERVER['HTTP_REFERER'])) && (((isset($_SESSION['loginUsername'])) &
 
 			$insertGoTo = $base_url."setup.php?section=step2&go=".$username;
 			$_SESSION['loginUsername'] = $username;
+			csrf_token_generate(true);
 
 		}
 

--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -11,6 +11,23 @@
 include (LIB.'date_time.lib.php');
 include (INCLUDES.'version.inc.php');
 
+function csrf_token_generate($force_regenerate = false) {
+	if (
+		(!$force_regenerate) &&
+		(isset($_SESSION['user_session_token'])) &&
+		(is_string($_SESSION['user_session_token'])) &&
+		(preg_match('/^[a-f0-9]{64}$/i', $_SESSION['user_session_token']))
+	) {
+		return $_SESSION['user_session_token'];
+	}
+
+	if (function_exists('random_bytes')) $_SESSION['user_session_token'] = bin2hex(random_bytes(32));
+	elseif (function_exists('mcrypt_create_iv')) $_SESSION['user_session_token'] = bin2hex(mcrypt_create_iv(32,MCRYPT_DEV_URANDOM));
+	else $_SESSION['user_session_token'] = bin2hex(openssl_random_pseudo_bytes(32));
+
+	return $_SESSION['user_session_token'];
+}
+
 /** ------------------ VERSION CHECK ------------------
  * Change version in system table if does not match in DB
  * If there are NO database structure or data updates for the current version,

--- a/qr.php
+++ b/qr.php
@@ -20,11 +20,7 @@ $totalRows_prefs = mysqli_num_rows($prefs);
 
 $_SESSION['prefsLanguage'] = $row_prefs['prefsLanguage'];
 
-if (($action != "update") && ($action != "password-check")) {
-	if (function_exists('random_bytes')) $_SESSION['user_session_token'] = bin2hex(random_bytes(32));
-	elseif (function_exists('mcrypt_create_iv')) $_SESSION['user_session_token'] = bin2hex(mcrypt_create_iv(32,MCRYPT_DEV_URANDOM));
-	else $_SESSION['user_session_token'] = bin2hex(openssl_random_pseudo_bytes(32));
-}
+if (($action != "update") && ($action != "password-check")) csrf_token_generate(false);
 
 // Check if variation used (demarked with a dash)
 if (strpos($row_prefs['prefsLanguage'], '-') !== FALSE) {
@@ -94,6 +90,7 @@ if ($action == "password-check") {
 				if ($check == 1) {
 					$password_redirect .= "&msg=2";
 					$_SESSION['qrPasswordOK'] = $password;
+					csrf_token_generate(true);
 				}
 
 				// If not successful, destroy session and redirect

--- a/setup.php
+++ b/setup.php
@@ -175,17 +175,10 @@ else {
 $security_question = array($label_secret_01, $label_secret_05, $label_secret_06, $label_secret_07, $label_secret_08, $label_secret_09, $label_secret_10, $label_secret_11, $label_secret_12, $label_secret_13, $label_secret_14, $label_secret_15, $label_secret_16, $label_secret_17, $label_secret_18, $label_secret_19, $label_secret_20, $label_secret_21, $label_secret_22, $label_secret_23, $label_secret_25, $label_secret_26, $label_secret_27);
 
 /**
- * Generate a CSRF token on every page load.
- * This will be used to prevent cross-site request forgeries
- * when processing form data.
- * First check for php 7 compatible random_bytes.
- * If not, use mcrypt_create_iv (deprecated in php 7.1 removed in 7.2)
- * If that's not available, default to openssl_random_pseudo_bytes.
+ * Ensure setup forms reuse the same CSRF token across page loads.
  */
 
-if (function_exists('random_bytes')) $_SESSION['user_session_token'] = bin2hex(random_bytes(32));
-elseif (function_exists('mcrypt_create_iv')) $_SESSION['user_session_token'] = bin2hex(mcrypt_create_iv(32,MCRYPT_DEV_URANDOM));
-else $_SESSION['user_session_token'] = bin2hex(openssl_random_pseudo_bytes(32));
+csrf_token_generate(false);
 
 ?>
 <!DOCTYPE html>


### PR DESCRIPTION
I noticed an issue where when opening multiple tabs/windows to the BCOE&M site where the first session would get a 403 and force log-out upon submitting a form.

This fixes a multi-tab session/CSRF issue where opening another BCOE&M page could invalidate an existing form in the first tab. In-progress unsaved edits, including judge/admin/user workflows, could then fail on save and appear as a session expiration. The change keeps the CSRF token stable across normal page loads and rotates it only on authentication-related transitions.
<img width="1080" height="614" alt="Screenshot 2026-03-11 at 4 19 14 PM" src="https://github.com/user-attachments/assets/6de76797-d0ce-4df6-b8d9-e704cfeee287" />

Please forgive my PHP naïveté