### PR TITLE
feat: add Első Magyar Házisörfőző Egyesület [Hungary] to clubs list

### DIFF
--- a/js_includes/clubs.js
+++ b/js_includes/clubs.js
@@ -767,6 +767,7 @@ const CLUBS = [
   "El Paso City Home Brewers",
   "El Riad Shrine Mystic Brewers",
   "Elba Mar Brewers Club",
+  "Első Magyar Házisörfőző Egyesület [Hungary]",
   "Elk County Brewers",
   "Elk Grove Brewers Guild",
   "Elkhorn Valley Society of Brewers",


### PR DESCRIPTION
## Summary

- Add **Első Magyar Házisörfőző Egyesület [Hungary]** (First Hungarian Homebrewing Association) to the global homebrew clubs list

## Files Changed

| File | Change |
|------|--------|
| `js_includes/clubs.js` | +1 club entry, inserted alphabetically |

## Test Plan

- [ ] Register a new account and verify the club appears in the club dropdown
- [ ] Verify the club is searchable via the live-search filter