### PR TITLE
Fix for login form (includes/logincheck.inc.php)

### DIFF
--- a/includes/logincheck.inc.php
+++ b/includes/logincheck.inc.php
@@ -25,8 +25,6 @@ if (strlen($entered_password) > 72) {
 	exit;
 }
 
-mysqli_real_escape_string($connection,$loginUsername);
-mysqli_real_escape_string($connection,$entered_password);
 $entered_password = md5($entered_password);
 
 /**
@@ -35,39 +33,40 @@ $entered_password = md5($entered_password);
  */
 
 if ($section == "update") {
-	
-	$loginUsername = strtolower($loginUsername);	
-	
-	$query_login = sprintf("SELECT * FROM %s WHERE user_name = '%s'",$prefix."users",$loginUsername);
-	$login = mysqli_query($connection,$query_login) or die("A database error occurred.");
+
+	$loginUsername = strtolower($loginUsername);
+
+	$stmt_login = mysqli_prepare($connection, sprintf("SELECT * FROM %s WHERE user_name = ?",$prefix."users")) or die("A database error occurred.");
+	mysqli_stmt_bind_param($stmt_login, "s", $loginUsername);
+	mysqli_stmt_execute($stmt_login);
+	$login = mysqli_stmt_get_result($stmt_login);
 	$row_login = mysqli_fetch_assoc($login);
 	$totalRows_login = mysqli_num_rows($login);
-	
+
 	$stored_hash = $row_login['password'];
-	
+
 	$check = 0;
-	
-	if ($totalRows_login > 0) {
-		$check = $hasher->CheckPassword($entered_password, $stored_hash);
-		$check = 1;
-	}
-	
+
+	if ($totalRows_login > 0) $check = $hasher->CheckPassword($entered_password, $stored_hash);
+
 	else $check = 0;
-	
+
 }
 
 if ($section != "update") {
-	
-	$loginUsername = strtolower($loginUsername);	
-	
-	$query_login = sprintf("SELECT * FROM %s WHERE user_name = '%s'", $prefix."users",$loginUsername);
-	$login = mysqli_query($connection,$query_login) or die("A database error occurred.");
+
+	$loginUsername = strtolower($loginUsername);
+
+	$stmt_login = mysqli_prepare($connection, sprintf("SELECT * FROM %s WHERE user_name = ?", $prefix."users")) or die("A database error occurred.");
+	mysqli_stmt_bind_param($stmt_login, "s", $loginUsername);
+	mysqli_stmt_execute($stmt_login);
+	$login = mysqli_stmt_get_result($stmt_login);
 	$row_login = mysqli_fetch_assoc($login);
 	$totalRows_login = mysqli_num_rows($login);
-	
+
 	$stored_hash = $row_login['password'];
 	$check = 0;
-	
+
 	if ($totalRows_login > 0) $check = $hasher->CheckPassword($entered_password, $stored_hash);
 
 }
@@ -80,14 +79,14 @@ if ($section != "update") {
 if ($check == 1) {
 	
 	// Register the loginUsername but first update the db record to make sure the the user name is stored as all lowercase.
-	$updateSQL = sprintf("UPDATE %s SET user_name='%s' WHERE id='%s'",$prefix."users",$loginUsername, $row_login['id']);
-	mysqli_real_escape_string($connection,$updateSQL);
-	$result = mysqli_query($connection,$updateSQL) or die("A database error occurred.");
+	$stmt_update = mysqli_prepare($connection, sprintf("UPDATE %s SET user_name=? WHERE id=?",$prefix."users")) or die("A database error occurred.");
+	mysqli_stmt_bind_param($stmt_update, "si", $loginUsername, $row_login['id']);
+	mysqli_stmt_execute($stmt_update);
 
 	// Convert email address in the user's accociated record in the "brewer" table
-	$updateSQL = sprintf("UPDATE %s SET brewerEmail='%s' WHERE uid='%s'",$prefix."brewer",$loginUsername, $row_login['id']);
-	mysqli_real_escape_string($connection,$updateSQL);
-	$result = mysqli_query($connection,$updateSQL) or die("A database error occurred.");
+	$stmt_update = mysqli_prepare($connection, sprintf("UPDATE %s SET brewerEmail=? WHERE uid=?",$prefix."brewer")) or die("A database error occurred.");
+	mysqli_stmt_bind_param($stmt_update, "si", $loginUsername, $row_login['id']);
+	mysqli_stmt_execute($stmt_update);
 	
 	// Register the session variable
 	$_SESSION['loginUsername'] = $loginUsername;


### PR DESCRIPTION
Risk
----
Every query in the login flow was built with sprintf() string interpolation of user-controlled input ($_POST['loginUsername']), guarded only by calls to mysqli_real_escape_string(). That function returns the escaped string rather than modifying its argument in place, and the return value was discarded in all four call sites in this file:

  - the two SELECT queries used to look up the account by username (one for the legacy "section=update" post-upgrade login path, one for the normal login path)
  - the two UPDATE queries that run immediately after a successful login to lower-case the stored username

Because the escaping calls were no-ops, $loginUsername reached these queries completely unsanitized. This is reachable pre-authentication by anyone who can submit the login form, so it's an unauthenticated SQL injection vector — the most severe kind, since it doesn't require any prior access to the application. Depending on DB privileges this can enable authentication bypass, arbitrary data read via UNION SELECT, or worse.

Fix
---
Converts all four queries to real parameterized prepared statements (mysqli_prepare / mysqli_stmt_bind_param / mysqli_stmt_execute / mysqli_stmt_get_result), so user input is always sent as data, never concatenated into SQL text. The dead mysqli_real_escape_string() calls are removed since they no longer serve any purpose once queries are parameterized.

mysqli_stmt_get_result() requires the mysqlnd driver, which has been the default mysqli driver since PHP 5.4 and is present on essentially all current PHP installs.

Also fixed in the same block: in the "section=update" branch (a one-time login path from the 1.3.0.0 password-hash migration, per the comment already in the file), the result of CheckPassword() was being unconditionally overwritten with `$check = 1` immediately after being computed:

    if ($totalRows_login > 0) {
        $check = $hasher->CheckPassword($entered_password, $stored_hash);
        $check = 1;
    }

This meant that path granted a successful login for any password as long as the username existed, independent of whether the password check passed. It's a separate bug from the injection issue (an authentication-logic bug rather than a SQL-construction bug), but it lives in the exact lines being touched here, so it's fixed alongside rather than left in place. The fix simply removes the stray `$check = 1` line so the actual CheckPassword() result governs authentication, matching the behavior of the normal (non-"update") login branch just below it.

No behavioral change for legitimate logins — same queries, same password verification logic (MD5 pre-hashing before phpass is left untouched here; that's tracked as a separate, independent fix since it's a distinct vulnerability class with its own migration considerations).