### PR TITLE
Fix MD5 password pre-hashing before bcrypt (all password sites)

### DIFF
--- a/includes/logincheck.inc.php
+++ b/includes/logincheck.inc.php
@@ -1,17 +1,15 @@
 <?php
 ob_start();
-require (CLASSES.'phpass/PasswordHash.php');
 
 $section = "default";
 if (isset($_GET['section'])) $section = sterilize($_GET['section']);
 
-header('Expires: Sat, 26 Jul 1997 05:00:00 GMT'); 
-header('Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT'); 
-header('Cache-Control: no-store, no-cache, must-revalidate'); 
-header('Cache-Control: post-check=0, pre-check=0', false); 
-header('Pragma: no-cache'); 
+header('Expires: Sat, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
 
-$hasher = new PasswordHash(8, false);
 $loginUsername = sterilize($_POST['loginUsername']);
 $entered_password = sterilize($_POST['loginPassword']);
 $location = $base_url."index.php?section=login";
@@ -19,7 +17,7 @@ $location = $base_url."index.php?section=login";
 if (NHC) $base_url = "../";
 else $base_url = $base_url;
 
-if (strlen($entered_password) > 72) { 
+if (strlen($entered_password) > 72) {
 	session_destroy();
 	header(sprintf("Location: %s", $base_url."index.php?msg=11"));
 	exit;
@@ -27,7 +25,6 @@ if (strlen($entered_password) > 72) {
 
 mysqli_real_escape_string($connection,$loginUsername);
 mysqli_real_escape_string($connection,$entered_password);
-$entered_password = md5($entered_password);
 
 /**
  * ONLY for 1.3.0.0 release; evaluate for deletion in future releases
@@ -35,40 +32,43 @@ $entered_password = md5($entered_password);
  */
 
 if ($section == "update") {
-	
-	$loginUsername = strtolower($loginUsername);	
-	
+
+	$loginUsername = strtolower($loginUsername);
+
 	$query_login = sprintf("SELECT * FROM %s WHERE user_name = '%s'",$prefix."users",$loginUsername);
 	$login = mysqli_query($connection,$query_login) or die("A database error occurred.");
 	$row_login = mysqli_fetch_assoc($login);
 	$totalRows_login = mysqli_num_rows($login);
-	
+
 	$stored_hash = $row_login['password'];
-	
+
 	$check = 0;
-	
+
 	if ($totalRows_login > 0) {
-		$check = $hasher->CheckPassword($entered_password, $stored_hash);
-		$check = 1;
+		$check = password_verify_legacy($entered_password, $stored_hash);
+		if (($check == 1) && (password_needs_legacy_upgrade($stored_hash))) upgrade_legacy_password_hash($connection, $prefix."users", "id", $row_login['id'], $entered_password);
 	}
-	
+
 	else $check = 0;
-	
+
 }
 
 if ($section != "update") {
-	
-	$loginUsername = strtolower($loginUsername);	
-	
+
+	$loginUsername = strtolower($loginUsername);
+
 	$query_login = sprintf("SELECT * FROM %s WHERE user_name = '%s'", $prefix."users",$loginUsername);
 	$login = mysqli_query($connection,$query_login) or die("A database error occurred.");
 	$row_login = mysqli_fetch_assoc($login);
 	$totalRows_login = mysqli_num_rows($login);
-	
+
 	$stored_hash = $row_login['password'];
 	$check = 0;
-	
-	if ($totalRows_login > 0) $check = $hasher->CheckPassword($entered_password, $stored_hash);
+
+	if ($totalRows_login > 0) {
+		$check = password_verify_legacy($entered_password, $stored_hash);
+		if (($check == 1) && (password_needs_legacy_upgrade($stored_hash))) upgrade_legacy_password_hash($connection, $prefix."users", "id", $row_login['id'], $entered_password);
+	}
 
 }
 

--- a/includes/process/process_comp_info.inc.php
+++ b/includes/process/process_comp_info.inc.php
@@ -120,10 +120,7 @@ if ((isset($_SERVER['HTTP_REFERER'])) && (((isset($_SESSION['loginUsername'])) &
 		$hash = NULL;
 
 		if (isset($_POST['contestCheckInPassword'])) {
-			require(CLASSES.'phpass/PasswordHash.php');
-			$hasher = new PasswordHash(8, false);
-			$entered_password = md5(sterilize($_POST['contestCheckInPassword']));
-			$hash = $hasher->HashPassword($entered_password);
+			$hash = password_hash(sterilize($_POST['contestCheckInPassword']), PASSWORD_BCRYPT);
 		}
 
 		$update_table = $prefix."contest_info";
@@ -228,10 +225,7 @@ if ((isset($_SERVER['HTTP_REFERER'])) && (((isset($_SESSION['loginUsername'])) &
 
 			if (isset($_POST['contestCheckInPassword'])) {
 
-				require(CLASSES.'phpass/PasswordHash.php');
-				$hasher = new PasswordHash(8, false);
-				$entered_password = md5(sterilize($_POST['contestCheckInPassword']));
-				$hash = $hasher->HashPassword($entered_password);
+				$hash = password_hash(sterilize($_POST['contestCheckInPassword']), PASSWORD_BCRYPT);
 
 				$update_table = $prefix."contest_info";
 				$data = array('contestCheckInPassword' => $hash);

--- a/includes/process/process_forgot_password.inc.php
+++ b/includes/process/process_forgot_password.inc.php
@@ -30,9 +30,7 @@ if ($action == "reset") {
 		if ((sterilize($_POST['newPassword1']) == sterilize($_POST['newPassword2']))) {
 			
 			// Hash
-			$entered_password = md5(sterilize($_POST['newPassword1']));
-			$hasher = new PasswordHash(8, false);
-			$hash = $hasher->HashPassword($entered_password);
+			$hash = password_hash(sterilize($_POST['newPassword1']), PASSWORD_BCRYPT);
 
 			// Insert the hash into the database
 			$update_table = $prefix."users";

--- a/includes/process/process_users.inc.php
+++ b/includes/process/process_users.inc.php
@@ -47,9 +47,7 @@ if (isset($_SERVER['HTTP_REFERER'])) {
 			else  {
 				
 				require(CLASSES.'phpass/PasswordHash.php');
-				$hasher = new PasswordHash(8, false);
-				$entered_password = md5($_POST['password']);
-				$hash = $hasher->HashPassword($entered_password);
+				$hash = password_hash($_POST['password'], PASSWORD_BCRYPT);
 				$hasher_question = new PasswordHash(8, false);
 				$hash_question = $hasher_question->HashPassword(sterilize($_POST['userQuestionAnswer']));
 
@@ -298,18 +296,15 @@ if (isset($_SERVER['HTTP_REFERER'])) {
 		if ($go == "password") {
 
 			// Check if old password is correct; if not redirect
-			require(CLASSES.'phpass/PasswordHash.php');
-			$hasher = new PasswordHash(8, false);
-
-			$password_old = md5(sterilize($_POST['passwordOld']));
-			$password_new = md5(sterilize($_POST['password']));
+			$password_old = sterilize($_POST['passwordOld']);
+			$password_new = sterilize($_POST['password']);
 
 			$query_userPass = sprintf("SELECT password FROM $users_db_table WHERE id = '%s'",$id);
 			$userPass = mysqli_query($connection,$query_userPass) or die (mysqli_error($connection));
 			$row_userPass = mysqli_fetch_assoc($userPass);
 
-			$check = $hasher->CheckPassword($password_old, $row_userPass['password']);
-			$hash_new = $hasher->HashPassword($password_new);
+			$check = password_verify_legacy($password_old, $row_userPass['password']);
+			$hash_new = password_hash($password_new, PASSWORD_BCRYPT);
 
 			if (!$check) {
 
@@ -344,17 +339,13 @@ if (isset($_SERVER['HTTP_REFERER'])) {
 		// --------------------------- If an admin is changing their password ------------------------------- //
 		if ($go == "change_user_password") {
 
-			require(CLASSES.'phpass/PasswordHash.php');
-			$hasher = new PasswordHash(8, false);
-
-			$password_new = md5(sterilize($_POST['password']));
-			$hash_new = $hasher->HashPassword($password_new);
+			$hash_new = password_hash(sterilize($_POST['password']), PASSWORD_BCRYPT);
 
 			$update_table = $prefix."users";
 			$data = array(
 				'password' => $hash_new,
 				'userCreated' => date('Y-m-d H:i:s', time())
-			);			
+			);
 			$db_conn->where ('id', $id);
 			$result = $db_conn->update ($update_table, $data);
 			if (!$result) {

--- a/includes/process/process_users_register.inc.php
+++ b/includes/process/process_users_register.inc.php
@@ -133,10 +133,8 @@ if (isset($_SERVER['HTTP_REFERER'])) {
 
 			} else {
 
-				// Add the user's creds to the "users" table			
-				$entered_password = md5($_POST['password']);
-				$hasher = new PasswordHash(8, false);
-				$hash = $hasher->HashPassword($entered_password);
+				// Add the user's creds to the "users" table
+				$hash = password_hash($_POST['password'], PASSWORD_BCRYPT);
 				$hasher_question = new PasswordHash(8, false);
 				$hash_question = $hasher_question->HashPassword(sterilize($userQuestionAnswer));
 

--- a/includes/process/process_users_setup.inc.php
+++ b/includes/process/process_users_setup.inc.php
@@ -23,9 +23,7 @@ if ((isset($_SERVER['HTTP_REFERER'])) && (((isset($_SESSION['loginUsername'])) &
 	if (strstr($username,'@'))  {
 
 		require(CLASSES.'phpass/PasswordHash.php');
-		$hasher = new PasswordHash(8, false);
-		$entered_password = md5($_POST['password']);
-		$hash = $hasher->HashPassword($entered_password);
+		$hash = password_hash($_POST['password'], PASSWORD_BCRYPT);
 		$hasher_question = new PasswordHash(8, false);
 		$hash_question = $hasher_question->HashPassword($userQuestionAnswer);
 

--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -23,6 +23,46 @@ function csrf_token_generate($force_regenerate = false) {
 	return $_SESSION['user_session_token'];
 }
 
+/**
+ * Verifies a plaintext password against a stored hash, transparently
+ * supporting both the current scheme (password_hash() over the raw
+ * plaintext, "$2y$" prefix) and the legacy scheme used before this fix
+ * (phpass HashPassword() over md5($plaintext), always "$2a$" prefix).
+ * Returns 1 on match, 0 otherwise, matching this codebase's existing
+ * $check convention.
+ */
+function password_verify_legacy($entered_password, $stored_hash) {
+	if (empty($stored_hash)) return 0;
+	if (password_verify($entered_password, $stored_hash)) return 1;
+	if ((strpos($stored_hash, '$2a$') === 0) && (password_verify(md5($entered_password), $stored_hash))) return 1;
+	return 0;
+}
+
+/**
+ * A stored hash needs upgrading if it was produced by the legacy
+ * md5-then-phpass scheme, identifiable by its "$2a$" prefix (phpass in
+ * this codebase is always configured to produce "$2a$" bcrypt hashes,
+ * never the portable "$P$" format). New hashes from password_hash()
+ * use PASSWORD_BCRYPT, which produces a "$2y$" prefix.
+ */
+function password_needs_legacy_upgrade($stored_hash) {
+	return (strpos($stored_hash, '$2a$') === 0);
+}
+
+/**
+ * Replaces a legacy password hash with a freshly-computed one now that
+ * the plaintext password is available (a successful login/verification
+ * is the only time the plaintext is ever in hand). Called after
+ * password_verify_legacy() succeeds via the legacy branch, so each
+ * account is upgraded once, on its next successful login.
+ */
+function upgrade_legacy_password_hash($connection, $table, $id_column, $id_value, $plaintext_password) {
+	$new_hash = password_hash($plaintext_password, PASSWORD_BCRYPT);
+	$stmt = mysqli_prepare($connection, sprintf("UPDATE %s SET password = ? WHERE %s = ?", $table, $id_column));
+	mysqli_stmt_bind_param($stmt, "si", $new_hash, $id_value);
+	mysqli_stmt_execute($stmt);
+}
+
 /** ------------------ VERSION CHECK ------------------
  * Change version in system table if does not match in DB
  * If there are NO database structure or data updates for the current version,

--- a/qr.php
+++ b/qr.php
@@ -56,9 +56,6 @@ if ($action == "password-check") {
 		header('Cache-Control: post-check=0, pre-check=0', false);
 		header('Pragma: no-cache');
 
-		require(CLASSES.'phpass/PasswordHash.php');
-		$hasher = new PasswordHash(8, false);
-
 		$password = sterilize($_POST['inputPassword']);
 
 		if (strlen($password) > 72) {
@@ -68,7 +65,6 @@ if ($action == "password-check") {
 		else {
 
 			mysqli_real_escape_string($connection,$password);
-			$password = md5($password);
 
 			// Check user input against DB
 			$query_qr_password = sprintf("SELECT contestCheckInPassword FROM %s WHERE id = '1'",$prefix."contest_info");
@@ -81,15 +77,15 @@ if ($action == "password-check") {
 			}
 
 			else {
-				
+
 				$stored_hash = $row_qr_password['contestCheckInPassword'];
-				$check = 0;
-				$check = $hasher->CheckPassword($password, $stored_hash);
+				$check = password_verify_legacy($password, $stored_hash);
+				if (($check == 1) && (password_needs_legacy_upgrade($stored_hash))) upgrade_legacy_password_hash($connection, $prefix."contest_info", "id", 1, $password);
 
 				// If successful, register a session variable and set the redirect
 				if ($check == 1) {
 					$password_redirect .= "&msg=2";
-					$_SESSION['qrPasswordOK'] = $password;
+					$_SESSION['qrPasswordOK'] = TRUE;
 					csrf_token_generate(true);
 				}
 


### PR DESCRIPTION
Risk
----
Every place in the app that hashes or verifies a password ran the plaintext through md5() first, then handed that 32-character hex digest to phpass's HashPassword()/CheckPassword() (bcrypt under the hood). This completely undermines bcrypt's actual purpose:

  - bcrypt is deliberately slow, so brute-forcing a real password (unbounded length, full character set) is expensive. Pre-hashing with MD5 collapses the input space down to a fixed 32-hex-char string, which is trivial to brute force or look up in a rainbow table, and once found, MD5(password) is exactly as good as the password itself for authenticating.
  - It provides no security benefit whatsoever over hashing the plaintext directly - MD5 is not a pepper, key, or salt here, it's just an extra, weak, unsalted hash wrapped around the real secret before the real (bcrypt) hash is computed.

This pattern was live in every password-handling path in the app: account registration, admin-created accounts, self-service password changes, admin-triggered password resets, forgot-password resets, the initial-setup admin account wizard, and the QR-code competition check-in password. All of these hash a password with the same undermined scheme, so all are fixed together here as one coherent change rather than piecemeal across multiple PRs.

Fix
---
New passwords are hashed directly with PHP's native password_hash($password, PASSWORD_BCRYPT) - no MD5, no phpass - in:
  - includes/process/process_users_register.inc.php (public/admin registration)
  - includes/process/process_users.inc.php (admin-add-user, self-service password change, admin-reset-user-password - 3 sites)
  - includes/process/process_users_setup.inc.php (initial setup wizard)
  - includes/process/process_forgot_password.inc.php (forgot-password reset)
  - includes/process/process_comp_info.inc.php (QR check-in password, add + edit - 2 sites)

Existing accounts' stored hashes were all produced by phpass's HashPassword(), which (as configured in this app) always emits a "$2a$"-prefixed bcrypt hash, regardless of whether the input was MD5 or plaintext. New hashes from password_hash(..., PASSWORD_BCRYPT) use PHP's own "$2y$" prefix. That gives a reliable way to tell old accounts from new ones without any new schema or flag, and enables a migration with no forced resets and no mass logout:

  lib/common.lib.php adds three small helpers:
    - password_verify_legacy($entered, $stored_hash): tries password_verify($entered, ...) first (the new, correct check); if that fails and the hash is "$2a$"-prefixed, falls back to password_verify(md5($entered), ...) (the old check). Returns 1/0 to match this codebase's existing $check convention.
    - password_needs_legacy_upgrade($stored_hash): true for "$2a$" hashes.
    - upgrade_legacy_password_hash(...): given the plaintext (only ever available right after a successful verification), recomputes and stores a fresh password_hash() hash via a parameterized UPDATE.

Verification call sites (includes/logincheck.inc.php, both the normal and legacy "section=update" login branches, and qr.php's check-in password check) call password_verify_legacy() first, then, only on a successful legacy-branch match, call upgrade_legacy_password_hash() so that account's hash is transparently migrated to the new scheme on its very next successful login/check-in - each account is upgraded exactly once, with no visible change for the user and no admin action required. Accounts that never log in again simply keep working via the legacy fallback indefinitely; there's no forced-reset deadline built into this change.

The self-service "change password" flow (process_users.inc.php) uses password_verify_legacy() to check the *old* password but does not need the upgrade helper, since it immediately overwrites the hash with a new one anyway.

Also fixed in includes/logincheck.inc.php: as part of rewriting the $check assignment in the "section=update" branch, this removes the same dead `$check = 1` unconditional overwrite noted in the SQL injection fix PR (both PRs touch this line for different reasons - whichever merges first, the other will need a small, obvious rebase).

Also fixed in qr.php: on successful check-in login, $_SESSION['qrPasswordOK'] was being set to the (formerly MD5'd, now plaintext) check-in password itself, even though every consumer of that session key only ever does isset() on it. Changed it to store TRUE instead, so a plaintext password is never placed in $_SESSION.

Not in scope here: the phpass library itself is left in place and still used for other purposes in these files (e.g. hashing the security-question answer), since replacing it everywhere is a larger, separate cleanup (tracked in the project's technical review as a P3 item) and not required to close this specific vulnerability.