### PR TITLE
Fix path traversal in the scoresheet PDF download handler (handle.php)

### DIFF
--- a/handle.php
+++ b/handle.php
@@ -6,9 +6,35 @@ require(LIB.'common.lib.php');
 // Force download of uploaded scoresheet PDF
 // Discourages random viewing of scoresheets by inputting direct URL
 if ((isset($_SESSION['loginUsername'])) && ($section == "pdf-download")) {
-	header("Content-disposition: attachment; filename=$id.pdf");
-	header("Content-type: application/pdf");
-	readfile(USER_DOCS."$id.pdf");
+
+	// $id becomes part of a filesystem path below, so it's restricted to a safe
+	// character set (no slashes, no "..") before being used at all. That alone
+	// isn't trusted as the only guard: the resolved real path is also required
+	// to still be inside USER_DOCS, so even a bug in the character check above
+	// can't turn this into a way to read arbitrary files on the server.
+	$pdf_path = NULL;
+
+	if ((preg_match('/^[a-zA-Z0-9._-]+$/', $id)) && (strpos($id, '..') === FALSE)) {
+
+		$user_docs_real = realpath(USER_DOCS);
+		$candidate_real = realpath(USER_DOCS.$id.".pdf");
+
+		if (($user_docs_real !== FALSE) && ($candidate_real !== FALSE) && (strncmp($candidate_real, $user_docs_real.DIRECTORY_SEPARATOR, strlen($user_docs_real.DIRECTORY_SEPARATOR)) === 0)) {
+			$pdf_path = $candidate_real;
+		}
+
+	}
+
+	if ($pdf_path !== NULL) {
+		header("Content-disposition: attachment; filename=$id.pdf");
+		header("Content-type: application/pdf");
+		readfile($pdf_path);
+	}
+
+	else {
+		header("HTTP/1.1 404 Not Found");
+	}
+
 }
 
 // Upload Function


### PR DESCRIPTION
Risk
----
The "pdf-download" branch of handle.php builds a filesystem path directly from the "id" query parameter and passes it to readfile():

    readfile(USER_DOCS."$id.pdf");

$id is populated by includes/url_variables.inc.php as sterilize($_GET['id']). sterilize() (paths.php) runs FILTER_SANITIZE_FULL_SPECIAL_CHARS, strip_tags(), and some slash- related escaping functions, but none of those strip or block "." or "/" - it's built for HTML/SQL-string safety, not path safety. So a request like:

    handle.php?section=pdf-download&id=../../../../etc/passwd%00

(or any "../" sequence pointing at a file outside USER_DOCS, using any filename the OS will let the web server user read - not limited to ".pdf" files despite the ".pdf" suffix appended in the code, since null-byte tricks aside, plenty of real targets don't need an extension trick at all, e.g. any actual *.pdf sitting elsewhere on disk) lets any logged-in user (this branch only checks isset($_SESSION['loginUsername']), not any particular privilege level) force the server to read and return an arbitrary file it has permission to read, rather than only files that were legitimately uploaded into USER_DOCS.

Fix
---
Two independent layers, so a mistake in one doesn't become a working exploit on its own:

  1. $id must match /^[a-zA-Z0-9._-]+$/ and must not contain "..". This rejects any path separator or traversal sequence before $id is used for anything.
  2. Regardless of (1), the actual file path is resolved with realpath() and required to still fall inside realpath(USER_DOCS) (compared with a trailing directory separator included, to avoid a sibling-directory false-positive like USER_DOCS resolving as a prefix of a differently-named neighboring directory). Only if both checks pass does readfile() run; otherwise the request gets a plain 404.

This means the fix doesn't rely solely on the regex being exactly right - even if the character class in (1) turned out to be too permissive, (2) independently confirms the resolved file is actually inside the intended directory before anything is read.

Verified with a standalone test (not committed - just used to check the logic before writing this commit) covering: a legitimate numeric id (resolves correctly), classic "../../../../etc/passwd" traversal (blocked), a bare ".." (blocked), a traversal sequence with the slash disguised inside an otherwise alphanumeric-looking value (blocked), and a well-formed id with no matching file (correctly falls through to 404 rather than erroring).

No change for legitimate downloads: a valid, existing "<id>.pdf" in USER_DOCS is served exactly as before, same headers, same content.