### PR TITLE
Add timezone override option for offset-based selections

### DIFF
--- a/lib/date_time.lib.php
+++ b/lib/date_time.lib.php
@@ -2,7 +2,22 @@
 function get_timezone($offset) {
 	
 	$offset = number_format($offset,3);
-	
+
+	// Allow per-installation timezone override via config.php.
+	//
+	// Some regions share the same UTC offset but need different timezone
+	// identifiers for correct display. For example, Asia/Seoul and
+	// Asia/Tokyo are both UTC+9 with no DST, but an installation in Korea
+	// should display "KST" (not "JST") to its users.
+	//
+	// Set $override_timezone in config.php to the desired PHP timezone
+	// identifier (e.g., 'Asia/Seoul') to override the offset-based mapping.
+	// If not set, the existing offset-based mapping below is used.
+	global $override_timezone;
+	if (isset($override_timezone) && !empty($override_timezone)) {
+		return $override_timezone;
+	}
+
 	$timezones = array(
         '-12.000' => 'Pacific/Kwajalein',
         '-11.000' => 'Pacific/Midway',


### PR DESCRIPTION
The current date_time.lib.php timezone functionality does not support localization within timezones, so this functionality provides an override.

By default, offset UTC+9 maps to Asia/Tokyo and dates are suffixed with JST (e.g. 2026/07/26 9:00, JST) by default. For an installation in Korea, we would like to map UTC+9 to Asia/Seoul so that dates are suffixed properly with KST (2026/07/26 9:00, KST).

This change exposes an additional override in config.php to localize the timezone. Example:
$override_timezone = 'Asia/Seoul';