### PR TITLE
Support Multi-Language Installation and User Language Toggle

### DIFF
--- a/includes/constants.inc.php
+++ b/includes/constants.inc.php
@@ -21,6 +21,25 @@ $languages = array(
     "es-419" => "Spanish (Latin America)"
 );
 
+/**
+ * Allow per-installation language override via config.php.
+ *
+ * Set $override_languages in config.php to restrict which languages
+ * are available on a given site. For example, a Korean competition
+ * might want only Korean and English:
+ *
+ *   $override_languages = array(
+ *       "ko-KR" => "한국어",
+ *       "en-US" => "English (US)"
+ *   );
+ *
+ * If $override_languages is not set, all languages defined above
+ * are available (default behavior, backwards-compatible).
+ */
+if (isset($override_languages) && !empty($override_languages)) {
+    $languages = $override_languages;
+}
+
 /** -------------------------- Theme File Names and Display Name -------------------------------
  * As of version 3.0.0, themes only apply to Admin functions.
  * The first item is the the CSS file name (without .css).

--- a/includes/constants.inc.php
+++ b/includes/constants.inc.php
@@ -22,19 +22,21 @@ $languages = array(
 );
 
 /**
- * Allow per-installation language override via config.php.
+ * Allow per-installation language override via config.php. Intended 
+ * for use with '$enable_language_toggle = TRUE'.
  *
  * Set $override_languages in config.php to restrict which languages
- * are available on a given site. For example, a Korean competition
- * might want only Korean and English:
+ * are available on a given site. For example, a multi-lingual 
+ * competition might want only English and Spanish:
  *
  *   $override_languages = array(
- *       "ko-KR" => "한국어",
- *       "en-US" => "English (US)"
+ *       "en-US" => "English (US)",
+ *       "es-419" => "Spanish (Latin America)"
  *   );
  *
- * If $override_languages is not set, all languages defined above
- * are available (default behavior, backwards-compatible).
+ * If $override_languages is not set, all default languages defined 
+ * above are available in the language drop-down when 
+ * $enable_language_toggle is enabled.
  */
 if (isset($override_languages) && !empty($override_languages)) {
     $languages = $override_languages;

--- a/lang/language.lang.php
+++ b/lang/language.lang.php
@@ -39,6 +39,27 @@ elseif ((!HOSTED) && (isset($_SESSION['prefsEmailSMTP']))) {
 $prefsLanguage = "en-US";
 $prefsLanguageFolder = "en";
 
+/**
+ * Per-session language override.
+ *
+ * Check for a user language cookie that allows users to switch languages
+ * independently of the site-wide default set in Site Preferences.
+ * The cookie is set by the language toggle in the navigation bar
+ * (pub/nav.pub.php) via the ?lang=XX URL parameter handled in bootstrap.php.
+ *
+ * The site-wide preference (from the DB) remains the default when
+ * no cookie is set. This runs on every page load, so the override
+ * takes effect immediately and persists across sessions (30-day cookie).
+ */
+if (isset($_COOKIE['userLanguage'])) {
+  $valid_langs = array_keys($languages);
+  if (in_array($_COOKIE['userLanguage'], $valid_langs)) {
+    $_SESSION['prefsLanguage'] = $_COOKIE['userLanguage'];
+    $lang_folder_parts = explode("-", $_COOKIE['userLanguage']);
+    $_SESSION['prefsLanguageFolder'] = strtolower($lang_folder_parts[0]);
+  }
+}
+
 if ((isset($_SESSION['prefsLanguage'])) && (!empty($_SESSION['prefsLanguage']))) {
   
   if (($_SESSION['prefsLanguage'] == "English") || ($_SESSION['prefsLanguage'] == "english")) {

--- a/lang/language.lang.php
+++ b/lang/language.lang.php
@@ -51,7 +51,7 @@ $prefsLanguageFolder = "en";
  * no cookie is set. This runs on every page load, so the override
  * takes effect immediately and persists across sessions (30-day cookie).
  */
-if (isset($_COOKIE['userLanguage'])) {
+if (isset($_COOKIE['userLanguage']) && isset($languages) && is_array($languages)) {
   $valid_langs = array_keys($languages);
   if (in_array($_COOKIE['userLanguage'], $valid_langs)) {
     $_SESSION['prefsLanguage'] = $_COOKIE['userLanguage'];

--- a/lang/language.lang.php
+++ b/lang/language.lang.php
@@ -42,16 +42,22 @@ $prefsLanguageFolder = "en";
 /**
  * Per-session language override.
  *
- * Check for a user language cookie that allows users to switch languages
- * independently of the site-wide default set in Site Preferences.
- * The cookie is set by the language toggle in the navigation bar
- * (pub/nav.pub.php) via the ?lang=XX URL parameter handled in bootstrap.php.
+ * Allows users to switch languages independently of the site-wide default
+ * set in Site Preferences. The cookie is set by the language toggle in
+ * the navigation bar (pub/nav.pub.php) via the ?lang=XX URL parameter
+ * handled in bootstrap.php.
+ *
+ * To enable this feature, set $enable_language_toggle = TRUE in config.php.
+ * By default, this feature is disabled and the site-wide preference is
+ * used exclusively (backwards-compatible with existing installations).
  *
  * The site-wide preference (from the DB) remains the default when
  * no cookie is set. This runs on every page load, so the override
  * takes effect immediately and persists across sessions (30-day cookie).
  */
-if (isset($_COOKIE['userLanguage']) && isset($languages) && is_array($languages)) {
+global $enable_language_toggle;
+if (isset($enable_language_toggle) && $enable_language_toggle
+    && isset($_COOKIE['userLanguage']) && isset($languages) && is_array($languages)) {
   $valid_langs = array_keys($languages);
   if (in_array($_COOKIE['userLanguage'], $valid_langs)) {
     $_SESSION['prefsLanguage'] = $_COOKIE['userLanguage'];

--- a/lang/language.lang.php
+++ b/lang/language.lang.php
@@ -40,7 +40,7 @@ $prefsLanguage = "en-US";
 $prefsLanguageFolder = "en";
 
 /**
- * Per-session language override.
+ * Per-session language override. 
  *
  * Allows users to switch languages independently of the site-wide default
  * set in Site Preferences. The cookie is set by the language toggle in

--- a/pub/nav.pub.php
+++ b/pub/nav.pub.php
@@ -102,9 +102,7 @@ if ($logged_in) {
 	            	<?php if (!$judging_started) { ?>
 	                <a class="nav-item nav-link" <?php echo $link_bs_target_toggle; ?> href="<?php echo $link_prefix; ?>#rules"><?php echo $label_rules; ?></a>
 	                <a class="nav-item nav-link" <?php echo $link_bs_target_toggle; ?> href="<?php echo $link_prefix; ?>#volunteers"><?php echo $label_volunteers; ?></a>
-	                <?php } ?>
-	                <?php if ($judging_past > 0) { ?>
-	                <a class="nav-item nav-link" <?php echo $link_bs_target_toggle; ?> href="<?php echo $link_prefix; ?>#entry-info"><?php echo $label_entry_info; ?></a>
+	            	<a class="nav-item nav-link" <?php echo $link_bs_target_toggle; ?> href="<?php echo $link_prefix; ?>#entry-info"><?php echo $label_entry_info; ?></a>
 	                <?php } ?>
 	            	<?php if (file_exists(PUB.'custom_competition_info.pub.php')) { ?>
 	            	<a class="nav-item nav-link" href="<?php echo build_public_url("competition","default","default","default",$sef,$base_url,"default"); ?>"><?php echo $label_other_info; ?></a>	
@@ -124,7 +122,15 @@ if ($logged_in) {
 	                // Shows a globe icon dropdown with available languages.
 	                // Only displayed if more than one language is enabled.
 	                // Users' selection is stored in a 30-day cookie (see bootstrap.php).
+	                // Links to the current page URL with ?lang= appended so users
+	                // don't lose their place when switching languages.
 	                if (count($languages) > 1) {
+	                    // Build the current page URL (without existing ?lang= param)
+	                    $current_url = $_SERVER['REQUEST_URI'];
+	                    // Strip any existing ?lang= parameter
+	                    $current_url = preg_replace('/[?&]lang=[^&]+/', '', $current_url);
+	                    // Determine separator (? or &)
+	                    $lang_sep = (strpos($current_url, '?') !== false) ? '&' : '?';
 	                ?>
 	                <div class="nav-item dropdown">
 	                    <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false" title="<?php echo $label_language ?? 'Language'; ?>">
@@ -135,7 +141,7 @@ if ($logged_in) {
 	                            $lang_active = (isset($_SESSION['prefsLanguage']) && $_SESSION['prefsLanguage'] == $lang_code);
 	                        ?>
 	                        <li class="small">
-	                            <a class="dropdown-item <?php if ($lang_active) echo "active"; ?>" href="<?php echo $base_url; ?>index.php?lang=<?php echo $lang_code; ?>">
+	                            <a class="dropdown-item <?php if ($lang_active) echo "active"; ?>" href="<?php echo $current_url . $lang_sep . 'lang=' . $lang_code; ?>">
 	                                <?php if ($lang_active) { ?><i class="fa fa-check text-success me-1"></i><?php } ?>
 	                                <?php echo $lang_name; ?>
 	                            </a>

--- a/pub/nav.pub.php
+++ b/pub/nav.pub.php
@@ -118,6 +118,33 @@ if ($logged_in) {
 	                <?php } if ($admin_user) { ?>
 	                <a class="nav-item nav-link" href="<?php echo $base_url."index.php?section=admin"; ?>"><?php echo $label_admin_short; ?></a>
 	                <?php } ?>
+
+	                <?php
+	                // --- Per-Session Language Toggle ---
+	                // Shows a globe icon dropdown with available languages.
+	                // Only displayed if more than one language is enabled.
+	                // Users' selection is stored in a 30-day cookie (see bootstrap.php).
+	                if (count($languages) > 1) {
+	                ?>
+	                <div class="nav-item dropdown">
+	                    <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false" title="<?php echo $label_language ?? 'Language'; ?>">
+	                        <i class="fa fa-lg fa-fw fa-globe"></i>
+	                    </a>
+	                    <ul class="dropdown-menu dropdown-menu-end" data-bs-theme="dark">
+	                        <?php foreach ($languages as $lang_code => $lang_name) {
+	                            $lang_active = (isset($_SESSION['prefsLanguage']) && $_SESSION['prefsLanguage'] == $lang_code);
+	                        ?>
+	                        <li class="small">
+	                            <a class="dropdown-item <?php if ($lang_active) echo "active"; ?>" href="<?php echo $base_url; ?>index.php?lang=<?php echo $lang_code; ?>">
+	                                <?php if ($lang_active) { ?><i class="fa fa-check text-success me-1"></i><?php } ?>
+	                                <?php echo $lang_name; ?>
+	                            </a>
+	                        </li>
+	                        <?php } ?>
+	                    </ul>
+	                </div>
+	                <?php } ?>
+
 	                <?php if ($logged_in) { ?>
                 	<li class="nav-item dropdown">
 						<a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false"><i class="fa fa-lg fa-fw fa-user"></i></a>

--- a/pub/nav.pub.php
+++ b/pub/nav.pub.php
@@ -100,12 +100,12 @@ if ($logged_in) {
 	            <?php } else { ?>
 
 	            	<?php if (!$judging_started) { ?>
-	            	<a class="nav-item nav-link" <?php echo $link_bs_target_toggle; ?> href="<?php echo $link_prefix; ?>#rules"><?php echo $label_rules; ?></a>
-	            	<a class="nav-item nav-link" <?php echo $link_bs_target_toggle; ?> href="<?php echo $link_prefix; ?>#volunteers"><?php echo $label_volunteers; ?></a>
-	            	<?php } ?>
-	            	<?php if ($judging_past > 0) { ?>
-	            	<a class="nav-item nav-link" <?php echo $link_bs_target_toggle; ?> href="<?php echo $link_prefix; ?>#entry-info"><?php echo $label_entry_info; ?></a>
-	            	<?php } ?>
+	                <a class="nav-item nav-link" <?php echo $link_bs_target_toggle; ?> href="<?php echo $link_prefix; ?>#rules"><?php echo $label_rules; ?></a>
+	                <a class="nav-item nav-link" <?php echo $link_bs_target_toggle; ?> href="<?php echo $link_prefix; ?>#volunteers"><?php echo $label_volunteers; ?></a>
+	                <?php } ?>
+	                <?php if ($judging_past > 0) { ?>
+	                <a class="nav-item nav-link" <?php echo $link_bs_target_toggle; ?> href="<?php echo $link_prefix; ?>#entry-info"><?php echo $label_entry_info; ?></a>
+	                <?php } ?>
 	            	<?php if (file_exists(PUB.'custom_competition_info.pub.php')) { ?>
 	            	<a class="nav-item nav-link" href="<?php echo build_public_url("competition","default","default","default",$sef,$base_url,"default"); ?>"><?php echo $label_other_info; ?></a>	
 	            	<?php } ?>

--- a/pub/nav.pub.php
+++ b/pub/nav.pub.php
@@ -100,10 +100,12 @@ if ($logged_in) {
 	            <?php } else { ?>
 
 	            	<?php if (!$judging_started) { ?>
-	                <a class="nav-item nav-link" <?php echo $link_bs_target_toggle; ?> href="<?php echo $link_prefix; ?>#rules"><?php echo $label_rules; ?></a>
-	                <a class="nav-item nav-link" <?php echo $link_bs_target_toggle; ?> href="<?php echo $link_prefix; ?>#volunteers"><?php echo $label_volunteers; ?></a>
+	            	<a class="nav-item nav-link" <?php echo $link_bs_target_toggle; ?> href="<?php echo $link_prefix; ?>#rules"><?php echo $label_rules; ?></a>
+	            	<a class="nav-item nav-link" <?php echo $link_bs_target_toggle; ?> href="<?php echo $link_prefix; ?>#volunteers"><?php echo $label_volunteers; ?></a>
+	            	<?php } ?>
+	            	<?php if ($judging_past > 0) { ?>
 	            	<a class="nav-item nav-link" <?php echo $link_bs_target_toggle; ?> href="<?php echo $link_prefix; ?>#entry-info"><?php echo $label_entry_info; ?></a>
-	                <?php } ?>
+	            	<?php } ?>
 	            	<?php if (file_exists(PUB.'custom_competition_info.pub.php')) { ?>
 	            	<a class="nav-item nav-link" href="<?php echo build_public_url("competition","default","default","default",$sef,$base_url,"default"); ?>"><?php echo $label_other_info; ?></a>	
 	            	<?php } ?>
@@ -120,11 +122,14 @@ if ($logged_in) {
 	                <?php
 	                // --- Per-Session Language Toggle ---
 	                // Shows a globe icon dropdown with available languages.
-	                // Only displayed if more than one language is enabled.
+	                // Only displayed when multi-language support is explicitly
+	                // enabled via $enable_language_toggle = TRUE in config.php
+	                // AND more than one language is available.
 	                // Users' selection is stored in a 30-day cookie (see bootstrap.php).
 	                // Links to the current page URL with ?lang= appended so users
 	                // don't lose their place when switching languages.
-	                if (count($languages) > 1) {
+	                global $enable_language_toggle;
+	                if (isset($enable_language_toggle) && $enable_language_toggle && count($languages) > 1) {
 	                    // Build the current page URL (without existing ?lang= param)
 	                    $current_url = $_SERVER['REQUEST_URI'];
 	                    // Strip any existing ?lang= parameter

--- a/pub/nav.pub.php
+++ b/pub/nav.pub.php
@@ -131,7 +131,7 @@ if ($logged_in) {
 	                global $enable_language_toggle;
 	                if (isset($enable_language_toggle) && $enable_language_toggle && count($languages) > 1) {
 	                    // Build the current page URL (without existing ?lang= param)
-	                    $current_url = $_SERVER['REQUEST_URI'];
+	                    $current_url = htmlspecialchars($_SERVER['REQUEST_URI'], ENT_QUOTES, 'UTF-8');
 	                    // Strip any existing ?lang= parameter
 	                    $current_url = preg_replace('/[?&]lang=[^&]+/', '', $current_url);
 	                    // Determine separator (? or &)
@@ -148,7 +148,7 @@ if ($logged_in) {
 	                        <li class="small">
 	                            <a class="dropdown-item <?php if ($lang_active) echo "active"; ?>" href="<?php echo $current_url . $lang_sep . 'lang=' . $lang_code; ?>">
 	                                <?php if ($lang_active) { ?><i class="fa fa-check text-success me-1"></i><?php } ?>
-	                                <?php echo $lang_name; ?>
+	                                <?php echo htmlspecialchars($lang_name, ENT_QUOTES, 'UTF-8'); ?>
 	                            </a>
 	                        </li>
 	                        <?php } ?>

--- a/pub/nav.pub.php
+++ b/pub/nav.pub.php
@@ -131,9 +131,7 @@ if ($logged_in) {
 	                global $enable_language_toggle;
 	                if (isset($enable_language_toggle) && $enable_language_toggle && count($languages) > 1) {
 	                    // Build the current page URL (without existing ?lang= param)
-	                    $current_url = htmlspecialchars($_SERVER['REQUEST_URI'], ENT_QUOTES, 'UTF-8');
-	                    // Strip any existing ?lang= parameter
-	                    $current_url = preg_replace('/[?&]lang=[^&]+/', '', $current_url);
+	                    $current_url = preg_replace('/[?&]lang=[^&]+/', '', $_SERVER['REQUEST_URI']);
 	                    // Determine separator (? or &)
 	                    $lang_sep = (strpos($current_url, '?') !== false) ? '&' : '?';
 	                ?>
@@ -146,7 +144,7 @@ if ($logged_in) {
 	                            $lang_active = (isset($_SESSION['prefsLanguage']) && $_SESSION['prefsLanguage'] == $lang_code);
 	                        ?>
 	                        <li class="small">
-	                            <a class="dropdown-item <?php if ($lang_active) echo "active"; ?>" href="<?php echo $current_url . $lang_sep . 'lang=' . $lang_code; ?>">
+	                            <a class="dropdown-item <?php if ($lang_active) echo "active"; ?>" href="<?php echo htmlspecialchars($current_url . $lang_sep . 'lang=' . $lang_code, ENT_QUOTES, 'UTF-8'); ?>">
 	                                <?php if ($lang_active) { ?><i class="fa fa-check text-success me-1"></i><?php } ?>
 	                                <?php echo htmlspecialchars($lang_name, ENT_QUOTES, 'UTF-8'); ?>
 	                            </a>

--- a/site/bootstrap.php
+++ b/site/bootstrap.php
@@ -66,6 +66,32 @@ if ($setup_success) {
 	require (DB.'brewer.db.php');
 	require (DB.'entries.db.php');
 	require (INCLUDES.'constants.inc.php');
+
+	// ---------------------------- Per-Session Language Override ----------------------------
+	// Handle ?lang=XX URL parameter to switch the user's display language.
+	// Sets a 30-day cookie and session variable, then redirects to the
+	// same page without the ?lang= parameter (clean URL).
+	// The cookie is checked on every subsequent page load in language.lang.php.
+	if (isset($_GET['lang'])) {
+		$valid_langs = array_keys($languages);
+		if (in_array($_GET['lang'], $valid_langs)) {
+			setcookie('userLanguage', $_GET['lang'], time() + (86400 * 30), "/");
+			$_SESSION['prefsLanguage'] = $_GET['lang'];
+			$lang_folder_parts = explode("-", $_GET['lang']);
+			$_SESSION['prefsLanguageFolder'] = strtolower($lang_folder_parts[0]);
+		}
+		// Redirect to the same page without the ?lang= parameter
+		$redirect_url = strtok($_SERVER["REQUEST_URI"], '?');
+		// Preserve other query params if any
+		$query_params = $_GET;
+		unset($query_params['lang']);
+		if (!empty($query_params)) {
+			$redirect_url .= '?' . http_build_query($query_params);
+		}
+		header("Location: " . $redirect_url);
+		exit;
+	}
+
 	require (LANG.'language.lang.php');
 	require (INCLUDES.'headers.inc.php');
 	require (INCLUDES.'scrubber.inc.php');

--- a/site/bootstrap.php
+++ b/site/bootstrap.php
@@ -69,8 +69,8 @@ if ($setup_success) {
 
 	// ---------------------------- Per-Session Language Override ----------------------------
 	// Handle ?lang=XX URL parameter to switch the user's display language.
-	// Sets a 30-day cookie and session variable, then redirects to the
-	// same page without the ?lang= parameter (clean URL).
+	// Sets a 30-day cookie and session variable, then continues rendering
+	// the current page (no redirect, so users don't lose form data).
 	// The cookie is checked on every subsequent page load in language.lang.php.
 	if (isset($_GET['lang'])) {
 		$valid_langs = array_keys($languages);
@@ -80,16 +80,8 @@ if ($setup_success) {
 			$lang_folder_parts = explode("-", $_GET['lang']);
 			$_SESSION['prefsLanguageFolder'] = strtolower($lang_folder_parts[0]);
 		}
-		// Redirect to the same page without the ?lang= parameter
-		$redirect_url = strtok($_SERVER["REQUEST_URI"], '?');
-		// Preserve other query params if any
-		$query_params = $_GET;
-		unset($query_params['lang']);
-		if (!empty($query_params)) {
-			$redirect_url .= '?' . http_build_query($query_params);
-		}
-		header("Location: " . $redirect_url);
-		exit;
+		// No redirect — continue rendering the current page with the new language.
+		// The ?lang= parameter is simply ignored on this page load.
 	}
 
 	require (LANG.'language.lang.php');

--- a/site/bootstrap.php
+++ b/site/bootstrap.php
@@ -76,6 +76,10 @@ if ($setup_success) {
 		$valid_langs = array_keys($languages);
 		if (in_array($_GET['lang'], $valid_langs)) {
 			setcookie('userLanguage', $_GET['lang'], time() + (86400 * 30), "/");
+			// Also update $_COOKIE so language.lang.php sees the new value
+			// immediately on this same page load (setcookie only affects
+			// the response header; $_COOKIE still holds the old request value).
+			$_COOKIE['userLanguage'] = $_GET['lang'];
 			$_SESSION['prefsLanguage'] = $_GET['lang'];
 			$lang_folder_parts = explode("-", $_GET['lang']);
 			$_SESSION['prefsLanguageFolder'] = strtolower($lang_folder_parts[0]);

--- a/site/bootstrap.php
+++ b/site/bootstrap.php
@@ -70,8 +70,8 @@ if ($setup_success) {
 	// ---------------------------- Per-Session Language Override ----------------------------
 	// Handle ?lang=XX URL parameter to switch the user's display language.
 	// Sets a 30-day cookie and session variable, then continues rendering
-	// the current page (no redirect, so users don't lose form data).
-	// The cookie is checked on every subsequent page load in language.lang.php.
+	// the current page. The cookie is checked on every subsequent page
+	// load in language.lang.php.
 	//
 	// This feature is disabled by default. To enable, set:
 	//   $enable_language_toggle = TRUE;

--- a/site/bootstrap.php
+++ b/site/bootstrap.php
@@ -84,7 +84,7 @@ if ($setup_success) {
 				'expires' => time() + (86400 * 30),
 				'path' => '/',
 				'httponly' => true,
-				'secure' => true,
+				'secure' => is_https(),
 				'samesite' => 'Lax',
 			]);
 			// Also update $_COOKIE so language.lang.php sees the new value

--- a/site/bootstrap.php
+++ b/site/bootstrap.php
@@ -80,7 +80,13 @@ if ($setup_success) {
 	if (isset($enable_language_toggle) && $enable_language_toggle && isset($_GET['lang'])) {
 		$valid_langs = array_keys($languages);
 		if (in_array($_GET['lang'], $valid_langs)) {
-			setcookie('userLanguage', $_GET['lang'], time() + (86400 * 30), "/");
+			setcookie('userLanguage', $_GET['lang'], [
+				'expires' => time() + (86400 * 30),
+				'path' => '/',
+				'httponly' => true,
+				'secure' => true,
+				'samesite' => 'Lax',
+			]);
 			// Also update $_COOKIE so language.lang.php sees the new value
 			// immediately on this same page load (setcookie only affects
 			// the response header; $_COOKIE still holds the old request value).

--- a/site/bootstrap.php
+++ b/site/bootstrap.php
@@ -72,7 +72,12 @@ if ($setup_success) {
 	// Sets a 30-day cookie and session variable, then continues rendering
 	// the current page (no redirect, so users don't lose form data).
 	// The cookie is checked on every subsequent page load in language.lang.php.
-	if (isset($_GET['lang'])) {
+	//
+	// This feature is disabled by default. To enable, set:
+	//   $enable_language_toggle = TRUE;
+	// in config.php. When disabled, ?lang= is ignored entirely.
+	global $enable_language_toggle;
+	if (isset($enable_language_toggle) && $enable_language_toggle && isset($_GET['lang'])) {
 		$valid_langs = array_keys($languages);
 		if (in_array($_GET['lang'], $valid_langs)) {
 			setcookie('userLanguage', $_GET['lang'], time() + (86400 * 30), "/");


### PR DESCRIPTION
This change adds support for multi-lingual competitions. When enabled, a language toggle is enabled within the navigation bar that allows users to select the language they wish the application to render. Administrators can enable multiple languages within the config.php file by adding:

$enable_language_toggle = TRUE;

By default, the language toggle is unavailable in the navigation bar and the site renders the language selected in the site's General Localization Preferences.

Once enabled, all languages configured in the system will be enabled for selection by the user. Administrators can limit the languages available in the drop-down by adding an override in the config.php file (for example, to enable only Korean and English):

$override_languages = array(
    "ko-KR" => "한국어",
    "en-US" => "English (US)"
);

Once the user selects a language, the value is stored in a cookie userLanguage that persists across sessions.