### PR TITLE
Fix custom style edit form populating with wrong style data (#1707)

### DIFF
--- a/includes/db/styles.db.php
+++ b/includes/db/styles.db.php
@@ -49,8 +49,8 @@ if ((($section == "admin") && ($go == "preferences")) || ($section == "step3")) 
 
 }
 
-if ($styleSet == "BJCP2025") $query_styles = sprintf("SELECT * FROM %s WHERE (brewStyleVersion='BJCP2025' AND brewStyleType='2') OR (brewStyleVersion='BJCP2021' AND brewStyleType !='2') OR brewStyleOwn='custom'", $styles_db_table);
-elseif ($styleSet == "AABC2025") $query_styles = sprintf("SELECT * FROM %s WHERE (brewStyleVersion='AABC2025' AND brewStyleType='2') OR (brewStyleVersion='AABC2022' AND brewStyleType !='2') OR brewStyleOwn='custom'", $styles_db_table);
+if ($styleSet == "BJCP2025") $query_styles = sprintf("SELECT * FROM %s WHERE ((brewStyleVersion='BJCP2025' AND brewStyleType='2') OR (brewStyleVersion='BJCP2021' AND brewStyleType !='2') OR brewStyleOwn='custom')", $styles_db_table);
+elseif ($styleSet == "AABC2025") $query_styles = sprintf("SELECT * FROM %s WHERE ((brewStyleVersion='AABC2025' AND brewStyleType='2') OR (brewStyleVersion='AABC2022' AND brewStyleType !='2') OR brewStyleOwn='custom')", $styles_db_table);
 else $query_styles = sprintf("SELECT * FROM %s WHERE (brewStyleVersion='%s' OR brewStyleOwn='custom')", $styles_db_table, $styleSet);
 
 if ($section == "admin") {
@@ -108,8 +108,8 @@ if ($section != "list") {
 	if (HOSTED) $query_styles2 = sprintf("SELECT * FROM %s WHERE (brewStyleVersion='%s' OR brewStyleOwn='custom') UNION ALL SELECT * FROM %s WHERE (brewStyleVersion='%s' OR brewStyleOwn='custom')", $styles_db_table, $styleSet, $prefix."styles", $styleSet);
 	else
 	*/
-	if ($styleSet == "BJCP2025") $query_styles2 = sprintf("SELECT * FROM %s WHERE (brewStyleVersion='BJCP2025' AND brewStyleType='2') OR (brewStyleVersion='BJCP2021' AND brewStyleType !='2') OR brewStyleOwn='custom'", $styles_db_table);
-	elseif ($styleSet == "AABC2025") $query_styles2 = sprintf("SELECT * FROM %s WHERE (brewStyleVersion='AABC2025' AND brewStyleType='2') OR (brewStyleVersion='AABC2022' AND brewStyleType !='2') OR brewStyleOwn='custom'", $styles_db_table);
+	if ($styleSet == "BJCP2025") $query_styles2 = sprintf("SELECT * FROM %s WHERE ((brewStyleVersion='BJCP2025' AND brewStyleType='2') OR (brewStyleVersion='BJCP2021' AND brewStyleType !='2') OR brewStyleOwn='custom')", $styles_db_table);
+	elseif ($styleSet == "AABC2025") $query_styles2 = sprintf("SELECT * FROM %s WHERE ((brewStyleVersion='AABC2025' AND brewStyleType='2') OR (brewStyleVersion='AABC2022' AND brewStyleType !='2') OR brewStyleOwn='custom')", $styles_db_table);
 	else $query_styles2 = sprintf("SELECT * FROM %s WHERE (brewStyleVersion='%s' OR brewStyleOwn='custom')", $styles_db_table, $styleSet);
 	if (($section == "judge") && ($go == "judge")) $query_styles2 .= " ORDER BY brewStyleType, brewStyleGroup, brewStyleNum ASC";
 	elseif ($section == "brew") $query_styles2 .= " AND brewStyleGroup > '28' AND brewStyleReqSpec = '1'";


### PR DESCRIPTION
## Fixes #1707

### Bug
Editing a custom style (Admin → Styles Accepted/Manage) loads the wrong style into the form regardless of which custom style was selected.

### Root cause
In `includes/db/styles.db.php`, the BJCP2025/AABC2025 style query is an unparenthesized OR chain:

```WHERE (brewStyleVersion='BJCP2025' AND brewStyleType='2') OR (brewStyleVersion='BJCP2021' AND brewStyleType !='2') OR brewStyleOwn='custom'```

The edit view then appends ` AND id='$id'` to the query intending to scope it to only one row.  However, the lack of encapsulating parenthesis results in the `AND id=` clause applying only to `OR brewStyleOwn=` letting rows from another style leak into the result set.  From this, only the first row is returned which is often not the expected/correct style.

### Fix
Wrap the OR chain in outer parentheses in `$query_styles` so that the appended `AND id='$id'` is applied to the entire conditional.  `$query_styles2` has an identical construction, so the fix was applied there as well for consistency though there does not seem to be any operation impact from the change.

### Verification
Reproduced locally and verified the fix addresses the issue.

### Impact
Only competitions on BJCP2025/AABC2025 (current defaults for new installs) are affected.