### PR TITLE
fix: show Scores - Manage to top-level admins when judging numbers are obfuscated

### DIFF
--- a/admin/default.admin.php
+++ b/admin/default.admin.php
@@ -1346,7 +1346,7 @@ if ($recently_updated) {
                                 </div>
                             </div>
                             <?php } ?>
-                            <?php if ($_SESSION['userAdminObfuscate'] == 0) { ?>
+                            <?php if (($_SESSION['userLevel'] == 0) || ($_SESSION['userAdminObfuscate'] == 0)) { ?>
                             <div class="row">
                                <div class="col col-lg-4 col-md-4 col-sm-4 col-xs-12 small">
                                     <strong>Scores</strong>

--- a/pub/admin-nav.pub.php
+++ b/pub/admin-nav.pub.php
@@ -244,7 +244,7 @@ if (($logged_in) && ($admin_user) && ($go != "error_page")) { ?>
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">Scoring <span class="caret"></span></a>
                 <ul class="dropdown-menu navmenu-nav">
                 	<li><a href="<?php echo $base_url; ?>index.php?section=admin&amp;go=upload_scoresheets">Upload Scoresheets</a></li>
-                <?php if ($_SESSION['userAdminObfuscate'] == 0) { ?>
+                <?php if (($_SESSION['userLevel'] == 0) || ($_SESSION['userAdminObfuscate'] == 0)) { ?>
                 	<?php if ($_SESSION['prefsEval'] == 1) { ?><li><a href="<?php echo $base_url; ?>index.php?section=evaluation&amp;go=default&amp;filter=default&amp;view=admin">Manage Entry Evaluations</a></li>
                 	<?php } ?>
                     <li><a href="<?php echo $base_url; ?>index.php?section=admin&amp;go=judging_scores">Manage Scores</a></li>

--- a/sections/nav.sec.php
+++ b/sections/nav.sec.php
@@ -218,7 +218,7 @@ if (($logged_in) && ($admin_user) && ($go != "error_page")) { ?>
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">Scoring <span class="caret"></span></a>
                 <ul class="dropdown-menu navmenu-nav">
                 	<li><a href="<?php echo $base_url; ?>index.php?section=admin&amp;go=upload_scoresheets">Upload Scoresheets</a></li>
-                <?php if ($_SESSION['userAdminObfuscate'] == 0) { ?>
+                <?php if (($_SESSION['userLevel'] == 0) || ($_SESSION['userAdminObfuscate'] == 0)) { ?>
                 	<?php if ($_SESSION['prefsEval'] == 1) { ?><li><a href="<?php echo $base_url; ?>index.php?section=admin&amp;go=evaluation&amp;filter=default&amp;view=admin">Manage Entry Evaluations</a></li>
                 	<?php } ?>
                     <li><a href="<?php echo $base_url; ?>index.php?section=admin&amp;go=judging_scores">Manage Scores</a></li>


### PR DESCRIPTION
## Summary

Fixes #1699.

Top-level admins (`userLevel == 0`) who have the **Obfuscate Judging Numbers** flag set lose the **Scores → Manage** and **BOS Entries and Places** links on the admin dashboard, and the **Manage Scores** / **Manage BOS Entries and Places** items in the Scoring navigation menu.

Those links are gated solely on `$_SESSION['userAdminObfuscate'] == 0`. Since `userLevel` and `userAdminObfuscate` are independent (a top-level admin can be obfuscated, per `includes/process/process_users.inc.php`), an obfuscated top-level admin cannot reach score management at all.

## Change

Relax the gating for top-level admins only: `(userLevel == 0) || (userAdminObfuscate == 0)` in the three scoring blocks:

- `admin/default.admin.php` — dashboard Scores / BOS Entries and Places block
- `pub/admin-nav.pub.php` — Scoring dropdown
- `sections/nav.sec.php` — Scoring dropdown

Lower-level admins keep the previous behavior: the links remain hidden when their judging numbers are obfuscated, because the scores screens display judging numbers (`admin/judging_scores.admin.php`, `admin/judging_scores_bos.admin.php`). The obfuscation flag is intended to hide judging numbers, not to deny score management to top-level admins.

## Verification

- Truth-matrix over user-level × obfuscation-flag combinations (top-level obfuscated → visible; lower admin obfuscated → still hidden; non-admins never reach the nav).
- Balanced PHP tags/braces in all three modified files (no PHP CLI available in this environment).