### PR TITLE
fix: URL-encode encrypted contact token in modal link (Issue #1708)

### DIFF
--- a/pub/contact.pub.php
+++ b/pub/contact.pub.php
@@ -63,7 +63,7 @@ elseif ($show_contact_list) {
             $nacl = base64_encode(bin2hex($server_root));
             $link = sprintf('%06d', $row_contact['id']);
             $link = simpleEncrypt($link, $secretKey, $nacl);
-            $email_redirect_link = sprintf("%sincludes/output.inc.php?section=contact&action=edit&tb=no-print&token=%s",$base_url,$link);
+            $email_redirect_link = sprintf("%sincludes/output.inc.php?section=contact&action=edit&tb=no-print&token=%s",$base_url,rawurlencode($link));
             $page_info .= sprintf("<li><a data-fancybox data-type=\"iframe\" class=\"modal-window-link hide-loader\" href=\"%s\">%s %s</a> &ndash; %s</li>",$email_redirect_link,h($row_contact['contactFirstName']),h($row_contact['contactLastName']),h($row_contact['contactPosition']));
 
     	}


### PR DESCRIPTION
## Summary

Fixes #1708 — "Contact modals occasionally return error rather than the actual contact details."

## Root cause

`pub/contact.pub.php` builds the contact-details modal link by embedding `simpleEncrypt()` output — base64 (alphabet includes `+`, `/`, `=`) — **raw** into the query string:

```php
$link = simpleEncrypt($link, $secretKey, $nacl);
$email_redirect_link = sprintf("%sincludes/output.inc.php?section=contact&action=edit&tb=no-print&token=%s",$base_url,$link);
```

PHP's query-string parser decodes `+` as a space. When the token contains `+` (it's random per page render because `simpleEncrypt` uses a fresh IV — roughly 28% of tokens, verified by simulation), the server receives a corrupted token, `simpleDecrypt` yields garbage, `contacts.db.php` runs `WHERE id='<garbage>'` and finds no row, and `output/print.output.php` renders the **Error** branch. Refreshing the page regenerates the token, which is why the bug is intermittent and "refresh fixes it."

## Fix

`rawurlencode($link)` when building the link. Round-trip is lossless; server-side `sterilize()` (identity on base64) and `simpleDecrypt()` are unaffected.

## Verification

5000-token simulation of the exact PHP `openssl_encrypt`/`openssl_decrypt` (AES-128-CBC, PKCS#7) round-trip through the query string:
- Old path (raw token): **1412 / 5000 failed (28%)**
- New path (rawurlencode): **0 / 5000 failed**
