### PR TITLE
fix: participant edit-save fatal on no-prefix installs

### DIFF
--- a/includes/db_tables.inc.php
+++ b/includes/db_tables.inc.php
@@ -16,6 +16,14 @@ Checked Single
 if ((isset($dbTable)) && ($dbTable != "default")) $dbTable = $dbTable;
 else $dbTable = "default";
 
+// A non-default $dbTable is an archive table name (e.g. "brewer_2024"), which
+// always contains an underscore. A base table name (e.g. "brewer", passed by
+// the participant edit form's POST action) has no underscore and must map to
+// the current competition's default tables. Treating a bare base-table name
+// as an archive identifier produced a bogus "brewer_" table and fataled the
+// edit-save path.
+if (($dbTable != "default") && (strpos($dbTable, "_") === false)) $dbTable = "default";
+
 if ($dbTable == "default") {
 	$archive_db_table = $prefix."archive";
 	$brewer_db_table = $prefix."brewer";


### PR DESCRIPTION
## Summary

For the new v3.1.0:

Fixes a white-page fatal when saving a participant edit (admin → Manage Participants → Edit → Save) on installs with no table prefix (`$prefix = ''`).

**Tested on a live install** ( PHP 8.3, no-prefix): the participant edit form renders and its save POST completes with zero fatals; archive viewing unaffected.

## Root cause

v3.1.0 (`a8092f18`) added `require db_tables.inc.php` to `includes/process.inc.php`. The archive branch of `db_tables.inc.php` treats **any** non-`default` `$dbTable` as an archive table name:

```php
if ($dbTable == "default") {
    $brewer_db_table = $prefix."brewer";   // current competition tables
    ...
} else {
    $suffix = rtrim(get_suffix($dbTable), "_");
    $brewer_db_table = $prefix."brewer".$suffix;   // archive tables
    ...
}
```

The participant edit form (`sections/brewer.sec.php`) POSTs `dbTable=<base table name>` — e.g. `dbTable=brewer` — because it interpolates the resolved `$brewer_db_table` into the form action:

```
includes/process.inc.php?section=admin&go=brewer&filter=1&action=edit&dbTable=brewer&id=1
```

With `$prefix = ''`, `$brewer_db_table = "brewer"` → `dbTable=brewer` → not `"default"` → archive branch → `get_suffix('brewer')` returns `""` → `$brewer_db_table = "brewer_"` → the update query hits a nonexistent `brewer_` table and fatals (white page, `display_errors=off`).

## Fix

Archive table names always contain an underscore (`brewer_2024`); base table names never do. Map a non-`default` `$dbTable` **without** an underscore back to the current competition's default tables:

```php
if (($dbTable != "default") && (strpos($dbTable, "_") === false)) $dbTable = "default";
```

## Verification

- Participant edit form renders (GET).
- Its save POST (`process.inc.php?...&action=edit&dbTable=brewer&id=1`) completes with zero fatals; the redirect fires.
- Archive viewing unaffected: archive links always pass `dbTable=brewer_<suffix>` (underscore present), which still enters the archive branch.