### PR TITLE
fix: preserve lowercase surname particles in name capitalization

### DIFF
--- a/includes/process/process_brewer_info.inc.php
+++ b/includes/process/process_brewer_info.inc.php
@@ -415,8 +415,12 @@ if (in_array($_SESSION['prefsLanguageFolder'], $name_check_langs)) {
     if (!empty($parsed_name['initials'])) $first_name .= " ".$parsed_name['initials'];
     
     $last_name = "";
-    if (in_array($_SESSION['prefsLanguageFolder'], $last_name_exception_langs)) $last_name .= standardize_name($parsed_name['lname']);
-    else $last_name .= $parsed_name['lname']; 
+    // Rebuild the last name from the compound particle(s) (preserved as entered,
+    // e.g. "van der", "de") plus the fix-cased base surname, rather than the
+    // fully fix-cased "lname" which would capitalize the particle(s).
+    if (!empty($parsed_name['lname_compound'])) $last_name .= $parsed_name['lname_compound']." ";
+    if (in_array($_SESSION['prefsLanguageFolder'], $last_name_exception_langs)) $last_name .= standardize_name($parsed_name['lname_base']);
+    else $last_name .= $parsed_name['lname_base'];
     if (!empty($parsed_name['suffix'])) $last_name .= " ".$parsed_name['suffix'];
 
 }

--- a/includes/process/process_brewing.inc.php
+++ b/includes/process/process_brewing.inc.php
@@ -148,8 +148,9 @@ if ((isset($_SERVER['HTTP_REFERER'])) && ((isset($_SESSION['loginUsername'])) &&
 			    if (!empty($parsed_name['initials'])) $first_name .= " ".$parsed_name['initials'];
 			    
 			    $last_name = "";
-			    if ((isset($_SESSION['prefsLanguageFolder'])) && (in_array($_SESSION['prefsLanguageFolder'], $last_name_exception_langs))) $last_name .= standardize_name($parsed_name['lname']);
-			    else $last_name .= $parsed_name['lname']; 
+			    if (!empty($parsed_name['lname_compound'])) $last_name .= $parsed_name['lname_compound']." ";
+			    if ((isset($_SESSION['prefsLanguageFolder'])) && (in_array($_SESSION['prefsLanguageFolder'], $last_name_exception_langs))) $last_name .= standardize_name($parsed_name['lname_base']);
+			    else $last_name .= $parsed_name['lname_base']; 
 			    if (!empty($parsed_name['suffix'])) $last_name .= " ".$parsed_name['suffix']; 
 
 			    $brewCoBrewer = $first_name." ".$last_name;

--- a/update/run_update.php
+++ b/update/run_update.php
@@ -1069,8 +1069,9 @@ if ($totalRows_names > 0) {
 		    if (!empty($parsed_name['initials'])) $first_name .= " ".$parsed_name['initials'];
 		    
 		    $last_name = "";
-		    if ((isset($row_current_prefs['prefsLanguageFolder'])) && (in_array($row_current_prefs['prefsLanguageFolder'], $last_name_exception_langs))) $last_name .= standardize_name($parsed_name['lname']);
-		    else $last_name .= $parsed_name['lname']; 
+		    if (!empty($parsed_name['lname_compound'])) $last_name .= $parsed_name['lname_compound']." ";
+		    if ((isset($row_current_prefs['prefsLanguageFolder'])) && (in_array($row_current_prefs['prefsLanguageFolder'], $last_name_exception_langs))) $last_name .= standardize_name($parsed_name['lname_base']);
+		    else $last_name .= $parsed_name['lname_base']; 
 		    if (!empty($parsed_name['suffix'])) $last_name .= " ".$parsed_name['suffix'];
 		}
 
@@ -1161,8 +1162,9 @@ if ($totalRows_entry_names > 0) {
 			    if (!empty($parsed_name['initials'])) $first_name .= " ".$parsed_name['initials'];
 			    
 			    $last_name = "";
-			    if ((isset($row_current_prefs['prefsLanguageFolder'])) && (in_array($row_current_prefs['prefsLanguageFolder'], $last_name_exception_langs))) $last_name .= standardize_name($parsed_name['lname']);
-			    else $last_name .= $parsed_name['lname']; 
+			    if (!empty($parsed_name['lname_compound'])) $last_name .= $parsed_name['lname_compound']." ";
+			    if ((isset($row_current_prefs['prefsLanguageFolder'])) && (in_array($row_current_prefs['prefsLanguageFolder'], $last_name_exception_langs))) $last_name .= standardize_name($parsed_name['lname_base']);
+			    else $last_name .= $parsed_name['lname_base']; 
 			    if (!empty($parsed_name['suffix'])) $last_name .= " ".$parsed_name['suffix']; 
 
 			    $brewCoBrewer = $first_name." ".$last_name;


### PR DESCRIPTION
## Summary

Of personal interest to me!! :)

Fixes participant names with lowercase surname particles (e.g. `van der`, `de`, `von`, `ter`, `della`, `St.`) being auto-capitalized on save — a surname entered as `van der Berg` was stored as `Van Der Berg`.

**Tested on a live install** (PHP 8.3, no-prefix): saving a participant with a lowercase particle surname now stores the particle as entered; normal names and compound/camelcase names (e.g. `McDonald`, `O'Brien`, `Kimura-Fay`) still capitalize correctly. Same fix applied to the co-brewer field and the upgrade name-standardization path.

## Root cause

`includes/process/process_brewer_info.inc.php` (and the co-brewer handler in `process_brewing.inc.php`, plus the name-standardization step in `update/run_update.php`) rebuild the last name from `$parsed_name['lname']` after running the vendored `FullNameParser` (`classes/capitalize_name/parser.php`).

`parse_name()` already splits compound surname particles into two parts:
- `lname_compound` — the particle(s), preserved **as entered** (`van der`, `de`, ...)
- `lname_base` — the base surname, passed through `fix_case()` (`Berg`, `Belder`, ...)

But the call sites used `lname` — the concatenation of both after `fix_case()`, which `ucfirst`s every word, capitalizing the particles:

```php
$last_name .= $parsed_name['lname'];   // "Van Der Berg" — particles capitalized
```

For `nl`/`es`/`de` languages, `standardize_name()` rescued the particles afterward; for all other languages (e.g. `en`, the live site's setting) the capitalization stuck.

## Fix

Rebuild the last name from the compound particle(s) (as entered) plus the fix-cased base:

```php
if (!empty($parsed_name['lname_compound'])) $last_name .= $parsed_name['lname_compound']." ";
if (in_array($_SESSION['prefsLanguageFolder'], $last_name_exception_langs)) $last_name .= standardize_name($parsed_name['lname_base']);
else $last_name .= $parsed_name['lname_base'];
```

`fix_case()` still normalizes the base surname (so `McDONALD` → `McDonald`), and the particle is preserved exactly as the user typed it (so `de Koenig` stays `de Koenig`, while a deliberately capitalized `De Koenig` also stays).

## Verification

- Live install: participant save with `van der Berg` stored as entered; `de Koenig` stored as entered; `John Smith` unchanged; `O'Brien`, `McDonald`, `Kimura-Fay`, `St. Clair` all correct.
- `php -l` clean on all three files.
- Parser behavior verified across `en`, `nl`, `de`, `es`, `fr`, `it`, `pt` language settings and edge cases (multiple particles, all-particle surnames, suffixes, initials).
