### PR TITLE
fix: reset MysqliDb bind state when a query fails

### DIFF
--- a/site/MysqliDb.php
+++ b/site/MysqliDb.php
@@ -758,11 +758,16 @@ class MysqliDb
             return $this;
         }
 
-        $stmt->execute();
-        $this->_stmtError = $stmt->error;
-        $this->_stmtErrno = $stmt->errno;
-        $res = $this->_dynamicBindResults($stmt);
-        $this->reset();
+        try {
+            $stmt->execute();
+            $this->_stmtError = $stmt->error;
+            $this->_stmtErrno = $stmt->errno;
+            $res = $this->_dynamicBindResults($stmt);
+        } finally {
+            // Always clear bind/where state, even when execute() or result
+            // binding throws, so a failed query cannot poison the next one.
+            $this->reset();
+        }
 
         return $res;
     }
@@ -2001,7 +2006,14 @@ class MysqliDb
      */
     protected function _prepareQuery()
     {
-        $stmt = $this->mysqli()->prepare($this->_query);
+        try {
+            $stmt = $this->mysqli()->prepare($this->_query);
+        } catch (mysqli_sql_exception $e) {
+            // Strict mysqli mode throws before the $stmt === false path below
+            // can run; leave the instance clean for the next query.
+            $this->reset();
+            throw $e;
+        }
 
         if ($stmt !== false) {
             if ($this->traceEnabled)


### PR DESCRIPTION
## Problem

A failed query could poison the next one. `get()` and `_prepareQuery()` only cleared `_bindParams` on the **success** path:

- `_prepareQuery()`: when mysqli is in strict mode (PHP 8.1+ default), `prepare()` **throws** `mysqli_sql_exception` before the existing `$stmt === false` failure path can run its `$this->reset()`. State stays dirty.
- `get()`: `reset()` runs only after a successful execute + fetch. If `execute()` or result binding throws, `_bindParams` keeps stale values.

Callers that catch query exceptions (e.g. a preferences lookup wrapped in try/catch) then leave the instance dirty; the next bound query appends its parameters on top of the stale ones → `ArgumentCountError: The number of variables must match the number of parameters in the prepared statement`.

Observed on the live site: a query against a column missing from the DB threw at prepare, the exception was swallowed by the caller, and the next query (sponsors) failed with the ArgumentCountError.

## Fix

- `_prepareQuery()`: catch `mysqli_sql_exception` from `prepare()`, reset instance state, rethrow. Mirrors the existing `$stmt === false` failure behavior for the strict-mode throw path.
- `get()`: wrap execute + result binding in try/finally so `reset()` always runs.

Net effect: a failed query always leaves the instance clean; failures degrade to their own exception instead of corrupting subsequent queries.

## Verification

- `php -l` clean.
- Sandbox repro of the original crash (deployed tree + live DB): before fix → fatal `ArgumentCountError` at sponsors query; after fix → full page renders, zero errors, hero sections present.
The same latent defect exists upstream (ThingEngineer/PHP-MySQLi-Database-Class) — this patch is against this repo's vendored copy.

---

Fixes #1732