### PR TITLE
fix: guard session user resolution against null lookups

### DIFF
--- a/includes/db/common.db.php
+++ b/includes/db/common.db.php
@@ -299,32 +299,32 @@ if ((isset($_SESSION['loginUsername'])) && ((!isset($_SESSION['user_info'.$prefi
 					if ($key != "id") $_SESSION[$key] = $value;
 				}
 				
-			}
+				$_SESSION['user_id'] = $row_user['id'];
 
-		    $_SESSION['user_id'] = $row_user['id'];
+				$db_conn->where ('uid', $row_user['id']);
+				$row_name = $db_conn->getOne ($prefix."brewer");
+				$totalRows_name = $db_conn->count; 
 
-		    $db_conn->where ('uid', $row_user['id']);
-			$row_name = $db_conn->getOne ($prefix."brewer");
-			$totalRows_name = $db_conn->count; 
+				/*
+				$query_name = sprintf("SELECT * FROM %s WHERE uid='%s'", $prefix."brewer", $row_user['id']);
+				$brewer_name = mysqli_query($connection,$query_name) or die (mysqli_error($connection));
+				$row_name = mysqli_fetch_assoc($brewer_name);
+				*/
+				
+				if ($totalRows_name > 0) {
 
-			/*
-			$query_name = sprintf("SELECT * FROM %s WHERE uid='%s'", $prefix."brewer", $row_user['id']);
-			$brewer_name = mysqli_query($connection,$query_name) or die (mysqli_error($connection));
-			$row_name = mysqli_fetch_assoc($brewer_name);
-			*/
-			
-			if ($totalRows_name > 0) {
+					$name_columns = array_keys($row_name);
 
-				$name_columns = array_keys($row_name);
+					foreach ($row_name as $key => $value) {
+						if ($key != "id") $_SESSION[$key] = $value;
+					}
 
-			    foreach ($row_name as $key => $value) {
-					if ($key != "id") $_SESSION[$key] = $value;
+					$_SESSION['brewerID'] = $row_name['id'];
 				}
 
-			}
+				$_SESSION['user_info'.$prefix_session] = $prefix_session;
 
-		    $_SESSION['brewerID'] = $row_name['id'];
-			$_SESSION['user_info'.$prefix_session] = $prefix_session;
+			}
 
 		}
 			

--- a/sections/nav.sec.php
+++ b/sections/nav.sec.php
@@ -135,14 +135,16 @@ if ($logged_in)  {
 
 	// Build Edit My Info link
     $edit_user_info_link = "";
-	if ($_SESSION['brewerID'] != "") $edit_user_info_link .= build_public_url("brewer","account","edit",$_SESSION['brewerID'],$sef,$base_url,"default");
+	if (!empty($_SESSION['brewerID'])) $edit_user_info_link .= build_public_url("brewer","account","edit",$_SESSION['brewerID'],$sef,$base_url,"default");
 
 	// Build Change My Email Address link
-	$edit_user_email_link = build_public_url("user","account","username",$_SESSION['user_id'],$sef,$base_url,"default");
+	$edit_user_email_link = "";
+	if (!empty($_SESSION['user_id'])) $edit_user_email_link .= build_public_url("user","account","username",$_SESSION['user_id'],$sef,$base_url,"default");
 	//$edit_user_email_link = $base_url."index.php?section=user&amp;action=username&amp;id=".$_SESSION['brewerID'];
 
 	// Build Change My Email Address link
-	$edit_user_password_link = build_public_url("user","account","password",$_SESSION['user_id'],$sef,$base_url,"default");
+	$edit_user_password_link = "";
+	if (!empty($_SESSION['user_id'])) $edit_user_password_link .= build_public_url("user","account","password",$_SESSION['user_id'],$sef,$base_url,"default");
 	//$edit_user_password_link = $base_url."index.php?section=user&amp;action=password&amp;id=".$_SESSION['brewerID'];
 
 	// Build Add Entry Link


### PR DESCRIPTION
## Problem

A logged-in admin whose session was wiped (e.g. session files removed on the server) could not log back in: the post-login admin render produced a white screen with zero entries in the PHP error log.

Root cause chain:

1. `includes/db/common.db.php` resolves session user info on the first request of a fresh session (`user_info<prefix>` marker absent): `WHERE user_name = $_SESSION['loginUsername']` -> `$row_user`.
2. `$_SESSION['user_id'] = $row_user['id'];` and `$_SESSION['brewerID'] = $row_name['id'];` ran **unconditionally**, even when the lookups returned no row -> nulls landed in the session.
3. `sections/nav.sec.php` passed `$_SESSION['user_id']` into `build_public_url(..., string $id, ...)` with no guard. Null -> uncaught `TypeError` -> with `display_errors` off, an empty 200 body (white screen) and no logged error.

Reproduced with the smoke harness against the live tree: `TypeError: build_public_url(): Argument #4 ($id) must be of type string, null given ... sections/nav.sec.php on line 141`.

## Fix

- `includes/db/common.db.php`: only write `$_SESSION['user_id']` / `$_SESSION['brewerID']` when the corresponding row was found; only set the `user_info<prefix>` marker on success so a failed resolution is retried next request instead of caching a broken state for the session.
- `sections/nav.sec.php`: guard the email/password link builders (and the Edit My Info link) with `!empty(...)` so a missing value can never reach the typed `string $id` parameter.

## Verification

- `php -l` clean on both files.
- Smoke harness against a sandbox copy of the live tree: admin render threw the TypeError before the fix; renders 375 KB of HTML after.
- Anonymous renders unaffected.

Fixes #1734
