### PR TITLE
fix(styles): include AABC2022 beer/mead styles in AABC2025 active-style queries

### DIFF
--- a/includes/constants.inc.php
+++ b/includes/constants.inc.php
@@ -662,6 +662,10 @@ if ((strpos($section, 'step') === FALSE) && (check_setup($prefix."bcoem_sys",$da
                 $query_styles_default = "SELECT id, brewStyle, brewStyleGroup, brewStyleNum, brewStyleVersion, brewStyleType FROM ".$prefix."styles WHERE (brewStyleVersion='BJCP2025' AND brewStyleType='2') OR (brewStyleVersion='BJCP2021' AND brewStyleType !='2')";
                 $rows_styles_default = $db_conn->rawQuery($query_styles_default);
             }
+            elseif ($prefsStyleSet == "AABC2025") {
+                $query_styles_default = "SELECT id, brewStyle, brewStyleGroup, brewStyleNum, brewStyleVersion, brewStyleType FROM ".$prefix."styles WHERE ((brewStyleVersion='AABC2025' AND brewStyleType='2') OR (brewStyleVersion='AABC2022' AND brewStyleType !='2') OR brewStyleOwn='custom')";
+                $rows_styles_default = $db_conn->rawQuery($query_styles_default);
+            }
             else {
                 $query_styles_default = "SELECT id, brewStyle, brewStyleGroup, brewStyleNum, brewStyleVersion, brewStyleType FROM ".$prefix."styles WHERE brewStyleVersion=?";
                 $rows_styles_default = $db_conn->rawQuery($query_styles_default, array($prefsStyleSet));

--- a/includes/process/process_prefs.inc.php
+++ b/includes/process/process_prefs.inc.php
@@ -734,7 +734,12 @@ if ((isset($_SERVER['HTTP_REFERER'])) && (((isset($_SESSION['loginUsername'])) &
 			if (($style_set_change) || (empty($prefsSelectedStyles))) {
 
 				$update_selected_styles = array();
-				$db_conn->where("brewStyleVersion", $prefsStyleSet);
+				if ($prefsStyleSet == "AABC2025") {
+					$db_conn->where("((brewStyleVersion='AABC2025' AND brewStyleType='2') OR (brewStyleVersion='AABC2022' AND brewStyleType !='2') OR brewStyleOwn='custom')");
+				}
+				else {
+					$db_conn->where("brewStyleVersion", $prefsStyleSet);
+				}
 				$rows_styles_default = $db_conn->get($styles_db_table, null, "id, brewStyle, brewStyleGroup, brewStyleNum, brewStyleVersion");
 
 				if ($rows_styles_default) {

--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -3938,6 +3938,10 @@ function styles_active($method,$archive="") {
 			$query_styles = "SELECT DISTINCT brewStyleGroup FROM ".$styles_db_table." WHERE ((brewStyleVersion='BJCP2025' AND brewStyleType='2') OR (brewStyleVersion='BJCP2021' AND brewStyleType !='2') OR brewStyleOwn='custom')";
 			$bind_params = array();
 		}
+		elseif ($style_set == "AABC2025") {
+			$query_styles = "SELECT DISTINCT brewStyleGroup FROM ".$styles_db_table." WHERE ((brewStyleVersion='AABC2025' AND brewStyleType='2') OR (brewStyleVersion='AABC2022' AND brewStyleType !='2') OR brewStyleOwn='custom')";
+			$bind_params = array();
+		}
 		else {
 			$query_styles = "SELECT DISTINCT brewStyleGroup FROM ".$styles_db_table." WHERE (brewStyleVersion=? OR brewStyleOwn='custom')";
 			$bind_params = array($style_set);
@@ -3975,11 +3979,18 @@ function styles_active($method,$archive="") {
 		if (HOSTED) $query_styles = sprintf("SELECT brewStyleGroup,brewStyleNum,brewStyle FROM %s WHERE (brewStyleVersion='%s' OR brewStyleOwn='custom') UNION ALL SELECT brewStyleGroup,brewStyleNum,brewStyle FROM %s WHERE (brewStyleVersion='%s' OR brewStyleOwn='custom')", $styles_db_table, $style_set, $prefix."styles", $style_set);
 		else 
 		*/
-		$query_styles = "SELECT brewStyleGroup,brewStyleNum,brewStyle FROM ".$styles_db_table." WHERE (brewStyleVersion=? OR brewStyleOwn='custom')";
+		if ($style_set == "AABC2025") {
+			$query_styles = "SELECT brewStyleGroup,brewStyleNum,brewStyle FROM ".$styles_db_table." WHERE ((brewStyleVersion='AABC2025' AND brewStyleType='2') OR (brewStyleVersion='AABC2022' AND brewStyleType !='2') OR brewStyleOwn='custom')";
+			$bind_params = array();
+		}
+		else {
+			$query_styles = "SELECT brewStyleGroup,brewStyleNum,brewStyle FROM ".$styles_db_table." WHERE (brewStyleVersion=? OR brewStyleOwn='custom')";
+			$bind_params = array($style_set);
+		}
 		if ((empty($archive)) || ($archive == "default")) $query_styles .= " AND brewStyleActive='Y'";
 		$query_styles .= " ORDER BY brewStyleGroup,brewStyleNum ASC";
 
-		$rows_styles = $db_conn->rawQuery($query_styles, array($style_set));
+		$rows_styles = $db_conn->rawQuery($query_styles, $bind_params);
 		$totalRows_styles = $db_conn->count;
 
 		$a = array();


### PR DESCRIPTION
## Summary

The AABC 2025 style set is deliberately split: the `AABC2025` package ships only the 16 cider styles (`brewStyleType='2'`, group 20), while beer (type 1) and mead (type 3, group 19) styles remain `brewStyleVersion='AABC2022'`. `includes/db/styles.db.php` models this correctly with a mixed-version predicate, but two code paths queried only `brewStyleVersion='AABC2025'` and therefore saw ONLY the ciders when `prefsStyleSet=AABC2025`, hiding every beer/mead category:

1. **`styles_active()` (lib/common.lib.php, methods 0 and 2)** — the main styles list and the group^num^name list. Impact: the By-Style / By-Sub-Style awards presentation slides (awards.php iterates `styles_active()`) showed no beer/mead categories, and best-brewer COA points were under-counted.
2. **`prefsSelectedStyles` regeneration (includes/process/process_prefs.inc.php)** — on style-set switch. Impact: the home-page category winners (`winners_category.sec.php` iterates `prefsSelectedStyles`) missed all beer/mead winners, and the style-selection UI default listed only ciders.

This matches the 2026-08-22 report on #1677 (including the "mead entries landed on the beer table" symptom — the category list never contained the mead group). It also explains why deleting scores changed nothing: these lists never read `judging_scores`.

## The Fix

When the effective style set is AABC2025, both sites now use the same mixed-version predicate that `styles.db.php` already uses:

`(brewStyleVersion='AABC2025' AND brewStyleType='2') OR (brewStyleVersion='AABC2022' AND brewStyleType !='2') OR brewStyleOwn='custom'`

- `styles_active()` methods 0 and 2 branch to this predicate, mirroring the existing BJCP2025 special case; all other style sets (BJCP2021/BJCP2025/AABC2022/BA/etc.) keep the original single-version predicate untouched.
- The `prefsSelectedStyles` regeneration in `process_prefs.inc.php` uses the same predicate, as does the failsafe regeneration of the same variable in `includes/constants.inc.php` (same defect path — it feeds the same home-page winners/UI-default consumers).
- Bound parameters are retained; no string interpolation of the style-set value.

## What's NOT covered

The global gate `COUNT(*) FROM judging_scores WHERE scorePlace IS NOT NULL` (includes/db/score_count.db.php) that suppresses ALL table winners on the presentation and home pages until some score has a place is a **separate defect** — see the issue comment on #1677. This PR only fixes the AABC2025 style-set filtering.

## Verification

- SQL-capture harness (`/tmp/defectb_check.php`, stubbed MysqliDb): `styles_active(0)` and `styles_active(2)` with AABC2025 produce the mixed predicate and no bare `brewStyleVersion='AABC2025'` equality-only filter; BJCP2021 keeps the original single-version predicate unchanged; the `process_prefs` regeneration behaves the same for AABC2025 and BJCP2021. All 14 checks pass.
- `php -l` clean on all three touched files.

## Notes

- **BJCP2025 asymmetry (intentionally untouched):** upstream's `styles_active()` method 0 carries the BJCP2025 mixed-version branch but method 2 does not, so By-Sub-Style presentation output is ciders-only for BJCP2025 even on stock master. This PR adds the AABC2025 branch to method 2 but leaves the pre-existing BJCP2025 method-2 gap alone to keep the diff minimal — happy to extend if desired.
- **Upgrade caveat for already-switched installs:** an installation that switched to AABC2025 *before* this fix has a ciders-only `prefsSelectedStyles` saved in the DB; the regeneration only runs on the next style-set save. After deploying, re-save the accepted-styles selection (or re-save preferences) once to regenerate the list with beer/mead styles.

Addresses part of #1677.