### PR TITLE
fix(styles): apply AABC2025 mixed-version predicate to remaining style queries

### DIFF
--- a/eval/db.eval.php
+++ b/eval/db.eval.php
@@ -25,6 +25,11 @@ if (empty($row_eval['evalStyle'])) {
 		$params_style = array($row_brewing['brewStyle'], $row_brewing['brewCategorySort'], $row_brewing['brewSubCategory']);
 	}
 
+	elseif ($_SESSION['prefsStyleSet'] == "AABC2025") {
+		$query_style = "SELECT id,brewStyle,brewStyleGroup,brewStyleNum,brewStyleType FROM ".$styles_db_table." WHERE brewStyle=? AND brewStyleGroup=? AND brewStyleNum=? AND (brewStyleVersion='AABC2025' OR brewStyleVersion='AABC2022')";
+		$params_style = array($row_brewing['brewStyle'], $row_brewing['brewCategorySort'], $row_brewing['brewSubCategory']);
+	}
+
 	else {
 		$query_style = "SELECT id,brewStyle,brewStyleGroup,brewStyleNum,brewStyleType FROM ".$styles_db_table." WHERE brewStyle=? AND brewStyleGroup=? AND brewStyleNum=? AND brewStyleVersion=?";
 		$params_style = array($row_brewing['brewStyle'], $row_brewing['brewCategorySort'], $row_brewing['brewSubCategory'], $_SESSION['prefsStyleSet']);

--- a/eval/judging_dashboard.eval.php
+++ b/eval/judging_dashboard.eval.php
@@ -26,6 +26,7 @@ if (TESTING) {
 	$db_conn->where ("brewStyleGroup", $row_entries['brewCategorySort']);
 	$db_conn->where ("brewStyleNum", $row_entries['brewSubCategory']);
 	if ($_SESSION['prefsStyleSet'] == "BJCP2025") $db_conn->where ("brewStyleVersion = ? OR brewStyleVersion = ?", array("BJCP2025","BJCP2021"));
+	elseif ($_SESSION['prefsStyleSet'] == "AABC2025") $db_conn->where ("brewStyleVersion = ? OR brewStyleVersion = ?", array("AABC2025","AABC2022"));
 	else $db_conn->where ("brewStyleVersion", $_SESSION['prefsStyleSet']);
 	$row_style = $db_conn->getOne ($prefix."styles", null, "brewStyleType");
 	

--- a/includes/db/output_labels_awards.db.php
+++ b/includes/db/output_labels_awards.db.php
@@ -45,6 +45,10 @@ if ($_SESSION['prefsWinnerMethod'] == "1") { // Output by Category
 		$query_styles = "SELECT * FROM ".$styles_db_table." WHERE (brewStyleVersion='BJCP2025' AND brewStyleType='2') OR (brewStyleVersion='BJCP2021' AND brewStyleType !='2') OR brewStyleOwn='custom' ORDER BY brewStyleGroup ASC";
 		$rows_styles = $db_conn->rawQuery($query_styles);
 	}
+	elseif ($styleSet == "AABC2025") {
+		$query_styles = "SELECT * FROM ".$styles_db_table." WHERE (brewStyleVersion='AABC2025' AND brewStyleType='2') OR (brewStyleVersion='AABC2022' AND brewStyleType !='2') OR brewStyleOwn='custom' ORDER BY brewStyleGroup ASC";
+		$rows_styles = $db_conn->rawQuery($query_styles);
+	}
 	else {
 		$query_styles = "SELECT id,brewStyleGroup FROM ".$styles_db_table." WHERE (brewStyleVersion=? OR brewStyleOwn='custom') ORDER BY brewStyleGroup ASC";
 		$rows_styles = $db_conn->rawQuery($query_styles, array($_SESSION['prefsStyleSet']));
@@ -116,6 +120,10 @@ elseif ($_SESSION['prefsWinnerMethod'] == "2") { // Output by sub-category
 
 	if ($styleSet == "BJCP2025") {
 		$query_styles = "SELECT * FROM ".$styles_db_table." WHERE (brewStyleVersion='BJCP2025' AND brewStyleType='2') OR (brewStyleVersion='BJCP2021' AND brewStyleType !='2') OR brewStyleOwn='custom' ORDER BY brewStyleGroup ASC";
+		$rows_styles = $db_conn->rawQuery($query_styles);
+	}
+	elseif ($styleSet == "AABC2025") {
+		$query_styles = "SELECT * FROM ".$styles_db_table." WHERE (brewStyleVersion='AABC2025' AND brewStyleType='2') OR (brewStyleVersion='AABC2022' AND brewStyleType !='2') OR brewStyleOwn='custom' ORDER BY brewStyleGroup ASC";
 		$rows_styles = $db_conn->rawQuery($query_styles);
 	}
 	else {

--- a/lib/admin.lib.php
+++ b/lib/admin.lib.php
@@ -939,6 +939,10 @@ function received_entries() {
 		$query_styles = "SELECT brewStyle FROM ".$prefix."styles"." WHERE (brewStyleVersion='BJCP2025' AND brewStyleType='2') OR (brewStyleVersion='BJCP2021' AND brewStyleType !='2') OR brewStyleOwn='custom'";
 		$rows_styles = $db_conn->rawQuery($query_styles);
 	}
+	elseif ($_SESSION['prefsStyleSet'] == "AABC2025") {
+		$query_styles = "SELECT brewStyle FROM ".$prefix."styles"." WHERE (brewStyleVersion='AABC2025' AND brewStyleType='2') OR (brewStyleVersion='AABC2022' AND brewStyleType !='2') OR brewStyleOwn='custom'";
+		$rows_styles = $db_conn->rawQuery($query_styles);
+	}
 	else {
 		$query_styles = "SELECT brewStyle FROM ".$prefix."styles"." WHERE (brewStyleVersion=? OR brewStyleOwn='custom')";
 		$rows_styles = $db_conn->rawQuery($query_styles, array($_SESSION['prefsStyleSet']));
@@ -954,6 +958,7 @@ function received_entries() {
 		if ($row['count'] > 0) $a[] = $style;
 	}
 	
+	// note: $b is never assigned before this check (pre-existing); returns "" until fixed
 	if (!empty($b))	$b = implode(",",$a);
 	else $b="";
 	return $b;

--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -433,6 +433,7 @@ function purge_entries($type, $interval) {
 
 		$params_check = array();
 		if ($_SESSION['prefsStyleSet'] == "BJCP2025") $query_check = "SELECT a.id, a.brewUpdated, a.brewInfo, a.brewCategorySort, a.brewSubCategory FROM ".$prefix."brewing"." as a, ".$styles_db_table." as b WHERE a.brewCategorySort=b.brewStyleGroup AND a.brewSubCategory=b.brewStyleNum AND b.brewStyleReqSpec=1 AND (a.brewInfo IS NULL OR a.brewInfo='') AND (b.brewStyleVersion = 'BJCP2021' OR b.brewStyleVersion = 'BJCP2025')";
+		elseif ($_SESSION['prefsStyleSet'] == "AABC2025") $query_check = "SELECT a.id, a.brewUpdated, a.brewInfo, a.brewCategorySort, a.brewSubCategory FROM ".$prefix."brewing"." as a, ".$styles_db_table." as b WHERE a.brewCategorySort=b.brewStyleGroup AND a.brewSubCategory=b.brewStyleNum AND b.brewStyleReqSpec=1 AND (a.brewInfo IS NULL OR a.brewInfo='') AND (b.brewStyleVersion = 'AABC2022' OR b.brewStyleVersion = 'AABC2025')";
 		else { $query_check = "SELECT a.id, a.brewUpdated, a.brewInfo, a.brewCategorySort, a.brewSubCategory FROM ".$prefix."brewing"." as a, ".$styles_db_table." as b WHERE a.brewCategorySort=b.brewStyleGroup AND a.brewSubCategory=b.brewStyleNum AND b.brewStyleReqSpec=1 AND (a.brewInfo IS NULL OR a.brewInfo='') AND b.brewStyleVersion = ?"; $params_check[] = $_SESSION['prefsStyleSet']; }
 		if ($interval > 0) $query_check .=" AND a.brewUpdated < DATE_SUB( NOW(), INTERVAL 1 DAY)";
 		$rows_check = (!empty($params_check)) ? $db_conn->rawQuery($query_check, $params_check) : $db_conn->rawQuery($query_check);

--- a/pub/eval_judging_dashboard.pub.php
+++ b/pub/eval_judging_dashboard.pub.php
@@ -16,6 +16,7 @@ if (TESTING) {
 	$db_conn->where ("brewStyleGroup", $row_entries['brewCategorySort']);
 	$db_conn->where ("brewStyleNum", $row_entries['brewSubCategory']);
 	if ($_SESSION['prefsStyleSet'] == "BJCP2025") $db_conn->where ("brewStyleVersion = ? OR brewStyleVersion = ?", array("BJCP2025","BJCP2021"));
+	elseif ($_SESSION['prefsStyleSet'] == "AABC2025") $db_conn->where ("brewStyleVersion = ? OR brewStyleVersion = ?", array("AABC2025","AABC2022"));
 	else $db_conn->where ("brewStyleVersion", $_SESSION['prefsStyleSet']);
 	$row_style = $db_conn->getOne ($prefix."styles", null, "brewStyleType");
 	


### PR DESCRIPTION
## Summary

Extends the AABC2025 mixed-version style predicate from #1737 to the remaining style-query sites found by sweeping the codebase. AABC2025 is a split style set: the `AABC2025` package ships only the 16 cider styles (`brewStyleType='2'`), while beer (type 1) and mead (type 3) styles remain `brewStyleVersion='AABC2022'`. Every site below queried only the single active style version and therefore produced empty/partial beer-mead output under AABC2025.

Each new branch mirrors the existing BJCP2025 branch at the same site and uses the predicate `(brewStyleVersion='AABC2025' AND brewStyleType='2') OR (brewStyleVersion='AABC2022' AND brewStyleType !='2') OR brewStyleOwn='custom'` (or the site's OR-group form), leaving all other style sets on the original single-version query.

## Sites fixed

- **`includes/db/output_labels_awards.db.php`** (By-Category and By-Subcategory award-label blocks) — AABC2025 `elseif` with the mixed predicate. Impact: award-label PDF printing produced no beer/mead labels under AABC2025.
- **`lib/admin.lib.php` `received_entries()`** — AABC2025 branch added to the style-list query. Impact: the admin "received entries" style list omitted beer/mead under AABC2025. (Note: the function currently always returns `""` due to a pre-existing typo at the `if (!empty($b))` check — `$b` is never assigned. Left untouched here; filed as a separate issue.)
- **`lib/common.lib.php` `purge_entries()`** type `"special"` — AABC2025 branch with `(b.brewStyleVersion = 'AABC2022' OR b.brewStyleVersion = 'AABC2025')`. Impact: the required-special-ingredients purge check skipped beer/mead entries under AABC2025.
- **`eval/db.eval.php`**, **`eval/judging_dashboard.eval.php`**, **`pub/eval_judging_dashboard.pub.php`** — AABC2025 branches with `(brewStyleVersion='AABC2025' OR brewStyleVersion='AABC2022')`. Impact: judge eval dashboards showed blank style info for beer/mead entries under AABC2025.

## Verified unreachable, intentionally not changed

The style-activation site at `includes/process/process_prefs.inc.php:533-535` (the 5th sweep hit) was verified unreachable in normal flows — add-path only, and the prefs row is always pre-seeded — so it was left as-is.

## Verification

- SQL-capture harness (`/tmp/defectb_check2.php`, stubbed MysqliDb): for each site, the branch logic is extracted verbatim from the working tree and eval'd. AABC2025 produces the mixed predicate (or AABC OR-group) with no bare single-version filter; BJCP2021 and other sets keep the original single-version query unchanged. All 19 checks pass.
- `php -l` clean on all six touched files.

Refs #1677
