### PR TITLE
fix(purge): report success when purge fully succeeds

### DIFF
--- a/includes/data_cleanup.inc.php
+++ b/includes/data_cleanup.inc.php
@@ -52,6 +52,7 @@ if ((isset($_SESSION['loginUsername'])) && ($_SESSION['userLevel'] == 0)) {
 		// Purge entry and associated data
 		if (($go == "entries") || ($go == "purge-all")) {
 
+			$count_results = 0;
 			$count_results_actual = 0;
 
 			// Purge all data from brewing table
@@ -158,7 +159,7 @@ if ((isset($_SESSION['loginUsername'])) && ($_SESSION['userLevel'] == 0)) {
 				);
 				if (SINGLE)	$db_conn->where ('comp_id', $_SESSION['comp_id']);
 				$result = $db_conn->update ($update_table, $data);
-				if ($result) $count_results += 1;
+				if (!$result) $count_results_actual += 1; // unpaired failure breaks equality -> status 0
 
 			}
 
@@ -175,6 +176,7 @@ if ((isset($_SESSION['loginUsername'])) && ($_SESSION['userLevel'] == 0)) {
 		// Purge participant and associated data
 		if (($go == "participants") || ($go == "purge-all")) {
 
+			$count_results = 0;
 			$count_results_actual = 0;
 
 			// Purge all data from brewer and users tables (except admins)
@@ -301,6 +303,7 @@ if ((isset($_SESSION['loginUsername'])) && ($_SESSION['userLevel'] == 0)) {
 		// Purge scores and associated data
 		if (($go == "scores") || ($go == "purge-all")) {
 
+			$count_results = 0;
 			$count_results_actual = 0;
 
 			$purge_array = array($judging_scores_db_table,$judging_scores_bos_db_table,$special_best_data_db_table);
@@ -331,6 +334,7 @@ if ((isset($_SESSION['loginUsername'])) && ($_SESSION['userLevel'] == 0)) {
 		// Purge judging tables and associated data
 		if (($go == "tables") || ($go == "purge-all")) {
 
+			$count_results = 0;
 			$count_results_actual = 0;
 
 			$purge_array = array($judging_tables_db_table,$judging_assignments_db_table,$judging_flights_db_table,$judging_scores_db_table,$special_best_data_db_table);
@@ -416,6 +420,7 @@ if ((isset($_SESSION['loginUsername'])) && ($_SESSION['userLevel'] == 0)) {
 
 		if (($go == "custom") || ($go == "purge-all")) {
 
+			$count_results = 0;
 			$count_results_actual = 0;
 
 			$purge_array = array($special_best_info_db_table,$special_best_data_db_table);
@@ -445,6 +450,7 @@ if ((isset($_SESSION['loginUsername'])) && ($_SESSION['userLevel'] == 0)) {
 
 		if (($go == "availability") || ($go == "purge-all")) {
 
+			$count_results = 0;
 			$count_results_actual = 0;
 
 			$update_table = $prefix."brewer";
@@ -578,6 +584,7 @@ if ((isset($_SESSION['loginUsername'])) && ($_SESSION['userLevel'] == 0)) {
 
 		if ((($go == "payments") || ($go == "purge-all")) && (table_exists($prefix."payments"))) {
 
+			$count_results = 0;
 			$count_results_actual = 0;
 
 			$update_table = $prefix."payments";


### PR DESCRIPTION
Fixes #1740

## Problem

Every purge reports "There was an error, please try again." even when it fully succeeds. The data is purged correctly; only the AJAX `status` flag is wrong. See #1740 for full root-cause analysis and history.

## Cause

The brewer-preferences update at the end of the entries-purge branch increments only `$count_results`, so the strict-equality success check `$count_results === $count_results_actual` can never pass. Additionally, `$count_results` was never reset between purge blocks, so multi-block `purge-all` requests compared cumulative vs per-block counters.

## Changes

`includes/data_cleanup.inc.php` (+8/−1):

1. The brewer update now marks *failure* instead of unpairing the counters:
   ```php
   if (!$result) $count_results_actual += 1; // unpaired failure breaks equality -> status 0
   ```
   Success preserves equality → `status 1`; failure breaks it → `status 0`.
2. `$count_results = 0;` added next to each existing `$count_results_actual = 0;` block reset (7 sites), so every block's equality check compares its own operations.

No behavioral change to what gets purged — this only fixes the reported status.

## Verification

- `php -l` clean.
- Reproduced on a live deployment (v3.1.0 MysqliDb lineage): entry purge emptied all four tables (`brewing`, `judging_scores`, `judging_scores_bos`, `special_best_data`) yet returned status 0 before the fix; counter logic verified correct after.