### PR TITLE
fix(styles): include AABC2022 beer/mead styles in style_convert() under AABC2025

### DIFF
--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -1454,6 +1454,10 @@ function style_convert($number,$type,$base_url="",$archive="") {
 		else $db_conn->where('brewStyleVersion', 'BJCP2021');
 		$row_style = $db_conn->getOne($styles_db_table, "brewStyleNum,brewStyleGroup,brewStyle,brewStyleVersion,brewStyleReqSpec,brewStyleOwn");
 	}
+	elseif ($style_set == "AABC2025") {
+		$query_style = "SELECT brewStyleNum,brewStyleGroup,brewStyle,brewStyleVersion,brewStyleReqSpec,brewStyleOwn FROM ".$styles_db_table." WHERE brewStyleGroup=? AND ((brewStyleVersion='AABC2025' AND brewStyleType='2') OR (brewStyleVersion='AABC2022' AND brewStyleType !='2') OR brewStyleOwn='custom')";
+		$row_style = $db_conn->rawQueryOne($query_style, array($number));
+	}
 	else {
 		$query_style = "SELECT brewStyleNum,brewStyleGroup,brewStyle,brewStyleVersion,brewStyleReqSpec,brewStyleOwn FROM ".$styles_db_table." WHERE brewStyleGroup=? AND (brewStyleVersion=? OR brewStyleOwn='custom')";
 		$row_style = $db_conn->rawQueryOne($query_style, array($number, $style_set));
@@ -1860,6 +1864,10 @@ function style_convert($number,$type,$base_url="",$archive="") {
 			$first_character = mb_substr($number[0], 0, 1);
 			if ($first_character == "C") $query_style = "SELECT brewStyleNum,brewStyleGroup,brewStyle,brewStyleVersion,brewStyleReqSpec,brewStyleStrength,brewStyleCarb,brewStyleSweet FROM ".$styles_db_table." WHERE brewStyleGroup=? AND brewStyleNum=? AND (brewStyleVersion='BJCP2025' OR brewStyleOwn='custom')";
 			else $query_style = "SELECT brewStyleNum,brewStyleGroup,brewStyle,brewStyleVersion,brewStyleReqSpec,brewStyleStrength,brewStyleCarb,brewStyleSweet FROM ".$styles_db_table." WHERE brewStyleGroup=? AND brewStyleNum=? AND (brewStyleVersion='BJCP2021' OR brewStyleOwn='custom')";
+			$row_style = $db_conn->rawQueryOne($query_style, array($number[0], $number[1]));
+		}
+		elseif ($number[2] == "AABC2025") {
+			$query_style = "SELECT brewStyleNum,brewStyleGroup,brewStyle,brewStyleVersion,brewStyleReqSpec,brewStyleStrength,brewStyleCarb,brewStyleSweet FROM ".$styles_db_table." WHERE brewStyleGroup=? AND brewStyleNum=? AND ((brewStyleVersion='AABC2025' AND brewStyleType='2') OR (brewStyleVersion='AABC2022' AND brewStyleType !='2') OR brewStyleOwn='custom')";
 			$row_style = $db_conn->rawQueryOne($query_style, array($number[0], $number[1]));
 		}
 		else {


### PR DESCRIPTION
## Summary

Third in the series (#1737, #1738). `style_convert()` in `lib/common.lib.php` looks up style rows by `brewStyleVersion = <active set>` only. Under AABC2025 that finds nothing for beer and mead, because the AABC2025 package ships only the 16 cider styles (`brewStyleType='2'`); beer (type 1) and mead (type 3) rows stay at `brewStyleVersion='AABC2022'`. Result: pull sheets and results output print the style number with no description.

Reported by @Simon-Haynes in [#1680 (comment)](https://github.com/geoffhumphrey/brewcompetitiononlineentry/issues/1680#issuecomment-5389650978): "the issue still manifests itself in pull sheets and the results tables, where it's not pulling the beer sub-style description, just the style and sub-style number - presumably because the code for those doesn't have the AABC 2022 fallback for beer".

## Sites fixed

Both version-filtered queries inside `style_convert()` get an AABC2025 branch mirroring the existing BJCP2025 branch, using the same predicate as #1737/#1738:

- **Group lookup** (top of function, feeds category names): `(brewStyleVersion='AABC2025' AND brewStyleType='2') OR (brewStyleVersion='AABC2022' AND brewStyleType !='2') OR brewStyleOwn='custom'`.
- **Case "9" detail lookup** (used by `pullsheets.output.php`): same predicate, combined with the group/num filters. The non-AABC branches are untouched, so every other style set keeps its original single-version query.

## Verification

- Branch-logic harness: `style_convert()` extracted verbatim from the working tree and run against a stubbed MysqliDb that captures the SQL. Four checks: AABC2025 produces the mixed predicate at both sites; BJCP2021 keeps the original single-version query at both sites. All pass.
- `php -l lib/common.lib.php` clean (pre-existing implicit-nullable deprecations unchanged).

Refs #1677
