### PR TITLE
Translate mead/cider carbonation and sweetness values on display pages

### DIFF
--- a/admin/entries.admin.php
+++ b/admin/entries.admin.php
@@ -216,7 +216,7 @@ if ($totalRows_log > 0) {
 
 		}
 
-		if (!empty($row_log['brewMead3'])) $cider_mead_req_info .= "<li><strong>".$label_strength.":</strong> ".h($row_log['brewMead3'])."</li>";
+		if (!empty($row_log['brewMead3'])) $cider_mead_req_info .= "<li><strong>".$label_strength.":</strong> ".translate_mead_strength_value(h($row_log['brewMead3']))."</li>";
 
 		if (!empty($cider_mead_req_info)) $required_info .= $cider_mead_req_info;
 

--- a/admin/entries.admin.php
+++ b/admin/entries.admin.php
@@ -196,8 +196,8 @@ if ($totalRows_log > 0) {
 
 		// Required Info for Cider / Mead (Strength, Carb, Sweetness)
 		$cider_mead_req_info = "";
-		if (!empty($row_log['brewMead1'])) $cider_mead_req_info .= "<li><strong>".$label_carbonation.":</strong> ".h($row_log['brewMead1'])."</li>";
-		if (!empty($row_log['brewMead2'])) $cider_mead_req_info .= "<li><strong>".$label_sweetness.":</strong> ".h($row_log['brewMead2'])."</li>";
+		if (!empty($row_log['brewMead1'])) $cider_mead_req_info .= "<li><strong>".$label_carbonation.":</strong> ".translate_mead_req_value($row_log['brewMead1'])."</li>";
+		if (!empty($row_log['brewMead2'])) $cider_mead_req_info .= "<li><strong>".$label_sweetness.":</strong> ".translate_mead_req_value($row_log['brewMead2'])."</li>";
 
 		if (!empty($row_log['brewSweetnessLevel'])) {
 

--- a/admin/entries.admin.php
+++ b/admin/entries.admin.php
@@ -196,8 +196,8 @@ if ($totalRows_log > 0) {
 
 		// Required Info for Cider / Mead (Strength, Carb, Sweetness)
 		$cider_mead_req_info = "";
-		if (!empty($row_log['brewMead1'])) $cider_mead_req_info .= "<li><strong>".$label_carbonation.":</strong> ".translate_mead_req_value($row_log['brewMead1'])."</li>";
-		if (!empty($row_log['brewMead2'])) $cider_mead_req_info .= "<li><strong>".$label_sweetness.":</strong> ".translate_mead_req_value($row_log['brewMead2'])."</li>";
+		if (!empty($row_log['brewMead1'])) $cider_mead_req_info .= "<li><strong>".$label_carbonation.":</strong> ".h(translate_mead_req_value($row_log['brewMead1']))."</li>";
+		if (!empty($row_log['brewMead2'])) $cider_mead_req_info .= "<li><strong>".$label_sweetness.":</strong> ".h(translate_mead_req_value($row_log['brewMead2']))."</li>";
 
 		if (!empty($row_log['brewSweetnessLevel'])) {
 
@@ -216,7 +216,7 @@ if ($totalRows_log > 0) {
 
 		}
 
-		if (!empty($row_log['brewMead3'])) $cider_mead_req_info .= "<li><strong>".$label_strength.":</strong> ".translate_mead_strength_value(h($row_log['brewMead3']))."</li>";
+		if (!empty($row_log['brewMead3'])) $cider_mead_req_info .= "<li><strong>".$label_strength.":</strong> ".h(translate_mead_strength_value($row_log['brewMead3']))."</li>";
 
 		if (!empty($cider_mead_req_info)) $required_info .= $cider_mead_req_info;
 

--- a/eval/scoresheet.eval.php
+++ b/eval/scoresheet.eval.php
@@ -415,21 +415,21 @@ if ($entry_found) {
   if (!empty($row_entry_info['brewMead1'])) {
     $entry_info_html .= "<div class=\"row bcoem-admin-element\">";
     $entry_info_html .= "<div class=\"col col-lg-3 col-md-4 col-sm-4 col-xs-12\"><strong>".$label_carbonation."</strong></div>";
-    $entry_info_html .= "<div class=\"col col-lg-9 col-md-8 col-sm-8 col-xs-12\">".$row_entry_info['brewMead1']."</div>";
+    $entry_info_html .= "<div class=\"col col-lg-9 col-md-8 col-sm-8 col-xs-12\">".h(translate_mead_req_value($row_entry_info['brewMead1']))."</div>";
     $entry_info_html .= "</div>";
   }
 
   if (!empty($row_entry_info['brewMead3'])) {
     $entry_info_html .= "<div class=\"row bcoem-admin-element\">";
     $entry_info_html .= "<div class=\"col col-lg-3 col-md-4 col-sm-4 col-xs-12\"><strong>".$label_strength."</strong></div>";
-    $entry_info_html .= "<div class=\"col col-lg-9 col-md-8 col-sm-8 col-xs-12\">".$row_entry_info['brewMead3']."</div>";
+    $entry_info_html .= "<div class=\"col col-lg-9 col-md-8 col-sm-8 col-xs-12\">".h(translate_mead_strength_value($row_entry_info['brewMead3']))."</div>";
     $entry_info_html .= "</div>";
   }
 
   if (!empty($row_entry_info['brewMead2'])) {
     $entry_info_html .= "<div class=\"row bcoem-admin-element\">";
     $entry_info_html .= "<div class=\"col col-lg-3 col-md-4 col-sm-4 col-xs-12\"><strong>".$label_sweetness."</strong></div>";
-    $entry_info_html .= "<div class=\"col col-lg-9 col-md-8 col-sm-8 col-xs-12\">".$row_entry_info['brewMead2']."</div>";
+    $entry_info_html .= "<div class=\"col col-lg-9 col-md-8 col-sm-8 col-xs-12\">".h(translate_mead_req_value($row_entry_info['brewMead2']))."</div>";
     $entry_info_html .= "</div>";
   }
 

--- a/includes/constants_post_lang.inc.php
+++ b/includes/constants_post_lang.inc.php
@@ -19,6 +19,30 @@ if (DEBUG) include (DEBUGGING.'query_count_begin.debug.php');
 
 csrf_token_generate(false);
 
+/**
+ * Stored-value → display-label maps for mead/cider required-info fields.
+ * brewMead1 (carbonation) and brewMead2 (sweetness/strength) store the
+ * English literal chosen at entry time; display pages need the matching
+ * $label_* decode. Follows the $style_types_translations pattern.
+ */
+
+$mead_carb_translations = array(
+    "Still"     => $label_still,
+    "Petillant" => $label_petillant,
+    "Sparkling" => $label_sparkling,
+);
+
+$mead_sweetness_translations = array(
+    "Dry"          => $label_dry,
+    "Medium Dry"   => $label_med_dry,
+    "Medium"       => $label_med,
+    "Medium Sweet" => $label_med_sweet,
+    "Sweet"        => $label_sweet,
+    // Cider sweetness values (brewMead2-cider radios)
+    "Semi-Dry"     => $label_semi_dry,
+    "Semi-Sweet"   => $label_semi_sweet,
+);
+
 // Bootstrap layout containers
 if (($section == "admin") || ($view == "admin")) {
     $container_main = "container-fluid";

--- a/includes/constants_post_lang.inc.php
+++ b/includes/constants_post_lang.inc.php
@@ -43,6 +43,15 @@ $mead_sweetness_translations = array(
     "Semi-Sweet"   => $label_semi_sweet,
 );
 
+/**
+ * Mead strength map (brewMead3): Hydromel/Standard/Sack.
+ */
+$mead_strength_translations = array(
+    "Hydromel" => $label_hydromel,
+    "Standard" => $label_standard,
+    "Sack"     => $label_sack,
+);
+
 // Bootstrap layout containers
 if (($section == "admin") || ($view == "admin")) {
     $container_main = "container-fluid";

--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -218,13 +218,47 @@ function in_string($haystack,$needle) {
 	if (strpos($haystack,$needle) !== false) return TRUE;
 }
 
+/**
+ * Translate a stored mead/cider required-info value (brewMead1/brewMead2)
+ * into its display-label decode. Unknown values pass through unchanged,
+ * so legacy data and other style sets are unaffected.
+ * Maps are defined in constants_post_lang.inc.php (after language load).
+ */
+function translate_mead_req_value($value) {
+
+	global $mead_carb_translations, $mead_sweetness_translations;
+
+	if (isset($mead_sweetness_translations[$value])) return $mead_sweetness_translations[$value];
+	if (isset($mead_carb_translations[$value])) return $mead_carb_translations[$value];
+	return $value;
+
+}
+
 function designations($judge_array,$display) {
 	$return = "";
 	$rank1 = explode(",",$judge_array);
 	foreach ($rank1 as $rank2) {
-		 if ($rank2 != $display) $return .= "<br />".$rank2."";
+		 if ($rank2 != $display) {
+			// Parse [other:text] format for custom designations
+			if (preg_match('/^\[other:(.*)\]$/', $rank2, $m)) {
+				$return .= "<br />".$m[1]."";
+			} else {
+				$return .= "<br />".$rank2."";
+			}
+		}
 	}
 	return $return;
+}
+
+/**
+ * Strip [other:text] tags and return clean designation text.
+ * Used for scoresheets, labels, exports, and admin views.
+ * @param string $rank_string The brewerJudgeRank value (comma-separated)
+ * @return string Cleaned string with [other:text] replaced by text
+ */
+function clean_designation_other($rank_string) {
+	if (empty($rank_string)) return $rank_string;
+	return preg_replace('/\[other:(.*?)\]/', '$1', $rank_string);
 }
 
 function build_action_link($icon,$base_url,$section,$go,$action,$filter,$id,$dbTable,$alt_title,$method=0,$tooltip_text="default") {

--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -234,31 +234,26 @@ function translate_mead_req_value($value) {
 
 }
 
+/**
+ * Translate a stored mead strength value (brewMead3:
+ * Hydromel/Standard/Sack). Unknown values pass through unchanged.
+ */
+function translate_mead_strength_value($value) {
+
+	global $mead_strength_translations;
+
+	if (isset($mead_strength_translations[$value])) return $mead_strength_translations[$value];
+	return $value;
+
+}
+
 function designations($judge_array,$display) {
 	$return = "";
 	$rank1 = explode(",",$judge_array);
 	foreach ($rank1 as $rank2) {
-		 if ($rank2 != $display) {
-			// Parse [other:text] format for custom designations
-			if (preg_match('/^\[other:(.*)\]$/', $rank2, $m)) {
-				$return .= "<br />".$m[1]."";
-			} else {
-				$return .= "<br />".$rank2."";
-			}
-		}
+		 if ($rank2 != $display) $return .= "<br />".$rank2."";
 	}
 	return $return;
-}
-
-/**
- * Strip [other:text] tags and return clean designation text.
- * Used for scoresheets, labels, exports, and admin views.
- * @param string $rank_string The brewerJudgeRank value (comma-separated)
- * @return string Cleaned string with [other:text] replaced by text
- */
-function clean_designation_other($rank_string) {
-	if (empty($rank_string)) return $rank_string;
-	return preg_replace('/\[other:(.*?)\]/', '$1', $rank_string);
 }
 
 function build_action_link($icon,$base_url,$section,$go,$action,$filter,$id,$dbTable,$alt_title,$method=0,$tooltip_text="default") {

--- a/output/bottle_label.output.php
+++ b/output/bottle_label.output.php
@@ -222,9 +222,9 @@ if (isset($_SESSION['loginUsername'])) {
               $brewMeadCider = "";
 
               if ((!empty($row_log['brewMead1'])) || (!empty($row_log['brewMead2'])) || (!empty($row_log['brewMead3']))) {
-                if (!empty($row_log['brewMead1'])) $brewMeadCider .= h($row_log['brewMead1'])."&nbsp;&nbsp;";
-                if (!empty($row_log['brewMead2'])) $brewMeadCider .= h($row_log['brewMead2'])."&nbsp;&nbsp;";
-                if (!empty($row_log['brewMead3'])) $brewMeadCider .= h($row_log['brewMead3']);
+                if (!empty($row_log['brewMead1'])) $brewMeadCider .= translate_mead_req_value(h($row_log['brewMead1']))."&nbsp;&nbsp;";
+                if (!empty($row_log['brewMead2'])) $brewMeadCider .= translate_mead_req_value(h($row_log['brewMead2']))."&nbsp;&nbsp;";
+                if (!empty($row_log['brewMead3'])) $brewMeadCider .= translate_mead_strength_value(h($row_log['brewMead3']));
               }
 
               if (!empty($row_log['brewInfo'])) {

--- a/output/bottle_label.output.php
+++ b/output/bottle_label.output.php
@@ -222,9 +222,9 @@ if (isset($_SESSION['loginUsername'])) {
               $brewMeadCider = "";
 
               if ((!empty($row_log['brewMead1'])) || (!empty($row_log['brewMead2'])) || (!empty($row_log['brewMead3']))) {
-                if (!empty($row_log['brewMead1'])) $brewMeadCider .= translate_mead_req_value(h($row_log['brewMead1']))."&nbsp;&nbsp;";
-                if (!empty($row_log['brewMead2'])) $brewMeadCider .= translate_mead_req_value(h($row_log['brewMead2']))."&nbsp;&nbsp;";
-                if (!empty($row_log['brewMead3'])) $brewMeadCider .= translate_mead_strength_value(h($row_log['brewMead3']));
+                if (!empty($row_log['brewMead1'])) $brewMeadCider .= h(translate_mead_req_value($row_log['brewMead1']))."&nbsp;&nbsp;";
+                if (!empty($row_log['brewMead2'])) $brewMeadCider .= h(translate_mead_req_value($row_log['brewMead2']))."&nbsp;&nbsp;";
+                if (!empty($row_log['brewMead3'])) $brewMeadCider .= h(translate_mead_strength_value($row_log['brewMead3']));
               }
 
               if (!empty($row_log['brewInfo'])) {

--- a/output/labels.output.php
+++ b/output/labels.output.php
@@ -606,9 +606,9 @@ if (isset($_SESSION['loginUsername'])) {
 						
 						if (in_array($style,$mead)) {
 
-							if (!empty($row_log['brewMead1'])) $entry_str_sweet_carb .= sprintf("*%s* ",$row_log['brewMead1']);
-							if (!empty($row_log['brewMead2'])) $entry_str_sweet_carb .= sprintf("*%s* ",$row_log['brewMead2']);
-							if (!empty($row_log['brewMead3'])) $entry_str_sweet_carb .= sprintf("*%s* ",$row_log['brewMead3']);
+							if (!empty($row_log['brewMead1'])) $entry_str_sweet_carb .= sprintf("*%s* ",translate_mead_req_value($row_log['brewMead1']));
+							if (!empty($row_log['brewMead2'])) $entry_str_sweet_carb .= sprintf("*%s* ",translate_mead_req_value($row_log['brewMead2']));
+							if (!empty($row_log['brewMead3'])) $entry_str_sweet_carb .= sprintf("*%s* ",translate_mead_strength_value($row_log['brewMead3']));
 
 							$entry_str_sweet_carb = str_replace("Medium Sweet", "Med Sweet", $entry_str_sweet_carb);
 							$entry_str_sweet_carb = str_replace("Medium Dry", "Med Dry", $entry_str_sweet_carb);

--- a/output/labels.output.php
+++ b/output/labels.output.php
@@ -606,9 +606,9 @@ if (isset($_SESSION['loginUsername'])) {
 						
 						if (in_array($style,$mead)) {
 
-							if (!empty($row_log['brewMead1'])) $entry_str_sweet_carb .= sprintf("*%s* ",translate_mead_req_value($row_log['brewMead1']));
-							if (!empty($row_log['brewMead2'])) $entry_str_sweet_carb .= sprintf("*%s* ",translate_mead_req_value($row_log['brewMead2']));
-							if (!empty($row_log['brewMead3'])) $entry_str_sweet_carb .= sprintf("*%s* ",translate_mead_strength_value($row_log['brewMead3']));
+							if (!empty($row_log['brewMead1'])) $entry_str_sweet_carb .= sprintf("*%s* ",h(translate_mead_req_value($row_log['brewMead1'])));
+							if (!empty($row_log['brewMead2'])) $entry_str_sweet_carb .= sprintf("*%s* ",h(translate_mead_req_value($row_log['brewMead2'])));
+							if (!empty($row_log['brewMead3'])) $entry_str_sweet_carb .= sprintf("*%s* ",h(translate_mead_strength_value($row_log['brewMead3'])));
 
 							$entry_str_sweet_carb = str_replace("Medium Sweet", "Med Sweet", $entry_str_sweet_carb);
 							$entry_str_sweet_carb = str_replace("Medium Dry", "Med Dry", $entry_str_sweet_carb);

--- a/pub/brewer_entries.pub.php
+++ b/pub/brewer_entries.pub.php
@@ -170,8 +170,8 @@ if ($totalRows_log > 0) {
 		}
 
 		$cider_mead_req_info = "";
-		if (!empty($row_log['brewMead1'])) $cider_mead_req_info .= "<li><strong>".$label_carbonation.":</strong> ".$row_log['brewMead1']."</li>";
-		if (!empty($row_log['brewMead2'])) $cider_mead_req_info .= "<li><strong>".$label_sweetness.":</strong> ".$row_log['brewMead2']."</li>";
+		if (!empty($row_log['brewMead1'])) $cider_mead_req_info .= "<li><strong>".$label_carbonation.":</strong> ".translate_mead_req_value($row_log['brewMead1'])."</li>";
+		if (!empty($row_log['brewMead2'])) $cider_mead_req_info .= "<li><strong>".$label_sweetness.":</strong> ".translate_mead_req_value($row_log['brewMead2'])."</li>";
 		
 		if (!empty($row_log['brewSweetnessLevel'])) {
 

--- a/pub/brewer_entries.pub.php
+++ b/pub/brewer_entries.pub.php
@@ -170,8 +170,8 @@ if ($totalRows_log > 0) {
 		}
 
 		$cider_mead_req_info = "";
-		if (!empty($row_log['brewMead1'])) $cider_mead_req_info .= "<li><strong>".$label_carbonation.":</strong> ".translate_mead_req_value($row_log['brewMead1'])."</li>";
-		if (!empty($row_log['brewMead2'])) $cider_mead_req_info .= "<li><strong>".$label_sweetness.":</strong> ".translate_mead_req_value($row_log['brewMead2'])."</li>";
+		if (!empty($row_log['brewMead1'])) $cider_mead_req_info .= "<li><strong>".$label_carbonation.":</strong> ".h(translate_mead_req_value($row_log['brewMead1']))."</li>";
+		if (!empty($row_log['brewMead2'])) $cider_mead_req_info .= "<li><strong>".$label_sweetness.":</strong> ".h(translate_mead_req_value($row_log['brewMead2']))."</li>";
 		
 		if (!empty($row_log['brewSweetnessLevel'])) {
 
@@ -190,7 +190,7 @@ if ($totalRows_log > 0) {
 		
 		}
 		
-		if (!empty($row_log['brewMead3'])) $cider_mead_req_info .= "<li><strong>".$label_strength.":</strong> ".translate_mead_strength_value($row_log['brewMead3'])."</li>";
+		if (!empty($row_log['brewMead3'])) $cider_mead_req_info .= "<li><strong>".$label_strength.":</strong> ".h(translate_mead_strength_value($row_log['brewMead3']))."</li>";
 		if (!empty($cider_mead_req_info)) $required_info .= $cider_mead_req_info;
 		if (!empty($row_log['brewABV'])) $required_info .= "<li><strong>".$label_abv.":</strong> ".$row_log['brewABV']."%</li>";
 

--- a/pub/brewer_entries.pub.php
+++ b/pub/brewer_entries.pub.php
@@ -190,7 +190,7 @@ if ($totalRows_log > 0) {
 		
 		}
 		
-		if (!empty($row_log['brewMead3'])) $cider_mead_req_info .= "<li><strong>".$label_strength.":</strong> ".$row_log['brewMead3']."</li>";
+		if (!empty($row_log['brewMead3'])) $cider_mead_req_info .= "<li><strong>".$label_strength.":</strong> ".translate_mead_strength_value($row_log['brewMead3'])."</li>";
 		if (!empty($cider_mead_req_info)) $required_info .= $cider_mead_req_info;
 		if (!empty($row_log['brewABV'])) $required_info .= "<li><strong>".$label_abv.":</strong> ".$row_log['brewABV']."%</li>";
 

--- a/pub/eval_dashboard.pub.php
+++ b/pub/eval_dashboard.pub.php
@@ -373,7 +373,7 @@ if ($totalRows_table_assignments > 0) {
 
 							if (!empty($row_entries['brewMead3'])) {
 								$additional_info++;
-								$strength_display .= "<strong>".$label_strength.":</strong> ".$row_entries['brewMead3'];
+								$strength_display .= "<strong>".$label_strength.":</strong> ".translate_mead_strength_value($row_entries['brewMead3']);
 							}
 
 							if (!empty($row_entries['brewPossAllergens'])) {

--- a/pub/eval_dashboard.pub.php
+++ b/pub/eval_dashboard.pub.php
@@ -345,12 +345,12 @@ if ($totalRows_table_assignments > 0) {
 
 							if (!empty($row_entries['brewMead1'])) {
 								$additional_info++;
-								$carb_display .= "<strong>".$label_carbonation.":</strong> ".translate_mead_req_value($row_entries['brewMead1']);
+								$carb_display .= "<strong>".$label_carbonation.":</strong> ".h(translate_mead_req_value($row_entries['brewMead1']));
 							}
 
 							if (!empty($row_entries['brewMead2'])) {
 								$additional_info++;
-								$sweetness_display .= "<strong>".$label_sweetness.":</strong> ".translate_mead_req_value($row_entries['brewMead2']);
+								$sweetness_display .= "<strong>".$label_sweetness.":</strong> ".h(translate_mead_req_value($row_entries['brewMead2']));
 							}
 
 							if (!empty($row_entries['brewSweetnessLevel'])) {
@@ -373,7 +373,7 @@ if ($totalRows_table_assignments > 0) {
 
 							if (!empty($row_entries['brewMead3'])) {
 								$additional_info++;
-								$strength_display .= "<strong>".$label_strength.":</strong> ".translate_mead_strength_value($row_entries['brewMead3']);
+								$strength_display .= "<strong>".$label_strength.":</strong> ".h(translate_mead_strength_value($row_entries['brewMead3']));
 							}
 
 							if (!empty($row_entries['brewPossAllergens'])) {

--- a/pub/eval_dashboard.pub.php
+++ b/pub/eval_dashboard.pub.php
@@ -345,12 +345,12 @@ if ($totalRows_table_assignments > 0) {
 
 							if (!empty($row_entries['brewMead1'])) {
 								$additional_info++;
-								$carb_display .= "<strong>".$label_carbonation.":</strong> ".$row_entries['brewMead1'];
+								$carb_display .= "<strong>".$label_carbonation.":</strong> ".translate_mead_req_value($row_entries['brewMead1']);
 							}
 
 							if (!empty($row_entries['brewMead2'])) {
 								$additional_info++;
-								$sweetness_display .= "<strong>".$label_sweetness.":</strong> ".$row_entries['brewMead2'];
+								$sweetness_display .= "<strong>".$label_sweetness.":</strong> ".translate_mead_req_value($row_entries['brewMead2']);
 							}
 
 							if (!empty($row_entries['brewSweetnessLevel'])) {

--- a/pub/eval_scoresheet.pub.php
+++ b/pub/eval_scoresheet.pub.php
@@ -438,7 +438,7 @@ if ($entry_found) {
   if (!empty($row_entry_info['brewMead3'])) {
     $entry_info_html .= "<div class=\"row mb-3\">";
     $entry_info_html .= "<div class=\"col-12 col-lg-3 col-md-4 col-sm-4\"><strong>".$label_strength."</strong></div>";
-    $entry_info_html .= "<div class=\"col-12 col-lg-9 col-md-8 col-sm-8\">".$row_entry_info['brewMead3']."</div>";
+    $entry_info_html .= "<div class=\"col-12 col-lg-9 col-md-8 col-sm-8\">".translate_mead_strength_value($row_entry_info['brewMead3'])."</div>";
     $entry_info_html .= "</div>";
   }
 

--- a/pub/eval_scoresheet.pub.php
+++ b/pub/eval_scoresheet.pub.php
@@ -438,7 +438,7 @@ if ($entry_found) {
   if (!empty($row_entry_info['brewMead3'])) {
     $entry_info_html .= "<div class=\"row mb-3\">";
     $entry_info_html .= "<div class=\"col-12 col-lg-3 col-md-4 col-sm-4\"><strong>".$label_strength."</strong></div>";
-    $entry_info_html .= "<div class=\"col-12 col-lg-9 col-md-8 col-sm-8\">".translate_mead_strength_value($row_entry_info['brewMead3'])."</div>";
+    $entry_info_html .= "<div class=\"col-12 col-lg-9 col-md-8 col-sm-8\">".h(translate_mead_strength_value($row_entry_info['brewMead3']))."</div>";
     $entry_info_html .= "</div>";
   }
 

--- a/sections/brewer_entries.sec.php
+++ b/sections/brewer_entries.sec.php
@@ -184,7 +184,7 @@ if ($totalRows_log > 0) {
 		
 		}
 		
-		if (!empty($row_log['brewMead3'])) $cider_mead_req_info .= "<li><strong>".$label_strength.":</strong> ".translate_mead_strength_value($row_log['brewMead3'])."</li>";
+		if (!empty($row_log['brewMead3'])) $cider_mead_req_info .= "<li><strong>".$label_strength.":</strong> ".h(translate_mead_strength_value($row_log['brewMead3']))."</li>";
 		if (!empty($cider_mead_req_info)) $required_info .= $cider_mead_req_info;
 
 		if (!empty($row_log['brewABV'])) $required_info .= "<li><strong>".$label_abv.":</strong> ".$row_log['brewABV']."%</li>";

--- a/sections/brewer_entries.sec.php
+++ b/sections/brewer_entries.sec.php
@@ -184,7 +184,7 @@ if ($totalRows_log > 0) {
 		
 		}
 		
-		if (!empty($row_log['brewMead3'])) $cider_mead_req_info .= "<li><strong>".$label_strength.":</strong> ".$row_log['brewMead3']."</li>";
+		if (!empty($row_log['brewMead3'])) $cider_mead_req_info .= "<li><strong>".$label_strength.":</strong> ".translate_mead_strength_value($row_log['brewMead3'])."</li>";
 		if (!empty($cider_mead_req_info)) $required_info .= $cider_mead_req_info;
 
 		if (!empty($row_log['brewABV'])) $required_info .= "<li><strong>".$label_abv.":</strong> ".$row_log['brewABV']."%</li>";


### PR DESCRIPTION
There are a few entry details relevant to Cider and Mead on the My Account page, Entry Label generation, and electronic scoresheets that are not properly translating. brewMead1 (carbonation), brewMead2 (sweetness), and brewMead3 (strength) store the English literal chosen at entry time ("Petillant", "Medium Dry", "Semi-Sweet", "Standard", ...), but display pages echoed the raw DB value while the entry form renders the choices via $label_* language decodes. Non-English locales therefore showed untranslated values on the Account entries page, admin entries view, electronic scoresheets, and printed entry labels (e.g. Korean: "탄산감: Petillant", "당도: Semi-Sweet", and a Mead label printing "Still … Medium Sweet").

Add stored-value → display-label maps in constants_post_lang.inc.php ($mead_carb_translations, $mead_sweetness_translations, $mead_strength_translations), following the $style_types_translations pattern, and translate_mead_req_value() / translate_mead_strength_value() lookups in lib/common.lib.php alongside the other value-mapping helpers (bjcp_rank, yes_no, designations). Apply them on:

- the Account entries page (brewer_entries.pub.php and the legacy brewer_entries.sec.php template)
- admin entries (entries.admin.php) - to cover possible future Admin translation functionality
- the eval dashboard (eval_dashboard.pub.php) and electronic scoresheets (eval_scoresheet.pub.php)
- entry label generation (bottle_label.output.php) and judge/entry labels (labels.output.php)

Unknown values pass through unchanged, so the functionality is backward compatible for legacy data and other style sets.