### PR TITLE
Store pouring instructions as locale-neutral keys; translate at display

### DIFF
--- a/admin/entries.admin.php
+++ b/admin/entries.admin.php
@@ -252,9 +252,9 @@ if ($totalRows_log > 0) {
 
 		if ((!empty($row_log['brewPouring'])) && ((!empty($row_log['brewStyleType'])) && ($row_log['brewStyleType'] == 1))) {
 			$pouring_arr = json_decode($row_log['brewPouring'],true);
-			$required_info .= "<li><strong>".$label_pouring.":</strong> ".h($pouring_arr['pouring'])."</li>";
+			$required_info .= "<li><strong>".$label_pouring.":</strong> ".h(translate_pouring_value($pouring_arr['pouring']))."</li>";
 			if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes']))) $required_info .= "<li><strong>".$label_pouring_notes.":</strong> ".$pouring_arr['pouring_notes']."</li>";
-			if ((isset($pouring_arr['pouring_rouse'])) && (!empty($pouring_arr['pouring_rouse']))) $required_info .= "<li><strong>".$label_rouse_yeast.":</strong> ".h($pouring_arr['pouring_rouse'])."</li>";
+			if ((isset($pouring_arr['pouring_rouse'])) && (!empty($pouring_arr['pouring_rouse']))) $required_info .= "<li><strong>".$label_rouse_yeast.":</strong> ".h(translate_pouring_rouse_value($pouring_arr['pouring_rouse']))."</li>";
 		}
 
 		// Allergens

--- a/eval/dashboard.eval.php
+++ b/eval/dashboard.eval.php
@@ -674,9 +674,9 @@ if ($totalRows_table_assignments > 0) {
 
 								if (!empty($row_entries['brewPouring'])) {
 									$pouring_arr = json_decode($row_entries['brewPouring'],true);
-									$pouring_display .= "<li><strong>".$label_pouring.":</strong> ".$pouring_arr['pouring']."</li>";
+									$pouring_display .= "<li><strong>".$label_pouring.":</strong> ".h(translate_pouring_value($pouring_arr['pouring']))."</li>";
 									if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes']))) $pouring_display .= "<li><strong>".$label_pouring_notes.":</strong> ".$pouring_arr['pouring_notes']."</li>";
-									if ((isset($pouring_arr['pouring_rouse'])) && (!empty($pouring_arr['pouring_rouse']))) $pouring_display .= "<li><strong>".$label_rouse_yeast.":</strong> ".$pouring_arr['pouring_rouse']."</li>";
+									if ((isset($pouring_arr['pouring_rouse'])) && (!empty($pouring_arr['pouring_rouse']))) $pouring_display .= "<li><strong>".$label_rouse_yeast.":</strong> ".h(translate_pouring_rouse_value($pouring_arr['pouring_rouse']))."</li>";
 									unset($pouring_arr);
 								}
 

--- a/eval/scoresheet.eval.php
+++ b/eval/scoresheet.eval.php
@@ -494,7 +494,7 @@ if ($entry_found) {
 
     $entry_info_html .= "<div class=\"row bcoem-admin-element\">";
     $entry_info_html .= "<div class=\"col col-lg-3 col-md-4 col-sm-4 col-xs-12\"><strong>".$label_pouring."</strong></div>";
-    $entry_info_html .= "<div class=\"col col-lg-9 col-md-8 col-sm-8 col-xs-12\">".$pouring_arr['pouring']."</div>";
+    $entry_info_html .= "<div class=\"col col-lg-9 col-md-8 col-sm-8 col-xs-12\">".h(translate_pouring_value($pouring_arr['pouring']))."</div>";
     $entry_info_html .= "</div>";
 
     if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes'])))  {
@@ -506,7 +506,7 @@ if ($entry_found) {
 
     $entry_info_html .= "<div class=\"row bcoem-admin-element\">";
     $entry_info_html .= "<div class=\"col col-lg-3 col-md-4 col-sm-4 col-xs-12\"><strong>".$label_rouse_yeast."</strong></div>";
-    $entry_info_html .= "<div class=\"col col-lg-9 col-md-8 col-sm-8 col-xs-12\">".$pouring_arr['pouring_rouse']."</div>";
+    $entry_info_html .= "<div class=\"col col-lg-9 col-md-8 col-sm-8 col-xs-12\">".h(translate_pouring_rouse_value($pouring_arr['pouring_rouse']))."</div>";
     $entry_info_html .= "</div>";
 
   }

--- a/includes/constants_post_lang.inc.php
+++ b/includes/constants_post_lang.inc.php
@@ -19,6 +19,22 @@ if (DEBUG) include (DEBUGGING.'query_count_begin.debug.php');
 
 csrf_token_generate(false);
 
+/**
+ * Pouring instruction maps (brewPouring JSON). Historic entries stored the
+ * translated literal (locale-dependent); new entries store locale-neutral
+ * keys. Values not present in the map pass through unchanged and display
+ * as stored (backwards compatibility with legacy locale-dependent data).
+ */
+$pouring_translations = array(
+    "fast"   => $label_fast,
+    "normal" => $label_normal,
+    "slow"   => $label_slow,
+);
+
+$pouring_rouse_translations = array(
+    "yes" => $label_yes,
+    "no"  => $label_no,
+);
 // Bootstrap layout containers
 if (($section == "admin") || ($view == "admin")) {
     $container_main = "container-fluid";

--- a/includes/process/process_brewing.inc.php
+++ b/includes/process/process_brewing.inc.php
@@ -235,11 +235,11 @@ if ((isset($_SERVER['HTTP_REFERER'])) && ((isset($_SESSION['loginUsername'])) &&
 		$pouring_instructions = array();
 
 		if ((isset($_POST['brewPouringInst'])) && (!empty($_POST['brewPouringInst']))) {
-			$pouring_instructions['pouring'] = sterilize($_POST['brewPouringInst']);		
+			$pouring_instructions['pouring'] = sterilize($_POST['brewPouringInst']);
 		}
 
 		if ((isset($_POST['brewPouringRouse'])) && (!empty($_POST['brewPouringRouse']))) {
-			$pouring_instructions['pouring_rouse'] = sterilize($_POST['brewPouringRouse']);		
+			$pouring_instructions['pouring_rouse'] = sterilize($_POST['brewPouringRouse']);
 		}
 
 		if ((isset($_POST['brewPouringNotes'])) && (!empty($_POST['brewPouringNotes']))) {
@@ -247,6 +247,24 @@ if ((isset($_SERVER['HTTP_REFERER'])) && ((isset($_SESSION['loginUsername'])) &&
 			$pouring_instructions['pouring_notes'] = $brewPouringNotes;
 		}
 
+		// On edit, if the pouring radio fields were absent from the POST
+		// (cross-locale edit where the legacy stored literal doesn't match
+		// any radio in the current locale, so no radio is pre-selected and
+		// the browser submits nothing), preserve the existing stored
+		// brewPouring values rather than overwriting them with empty.
+		if (($action == "edit") && (!isset($_POST['brewPouringInst']) || !isset($_POST['brewPouringRouse']))) {
+			$db_conn->where("id", $id);
+			$row_existing_pouring = $db_conn->getOne($brewing_db_table, "brewPouring");
+			if (!empty($row_existing_pouring['brewPouring'])) {
+				$existing_pouring_arr = json_decode($row_existing_pouring['brewPouring'], true);
+				if (!isset($pouring_instructions['pouring']) && isset($existing_pouring_arr['pouring']))
+					$pouring_instructions['pouring'] = $existing_pouring_arr['pouring'];
+				if (!isset($pouring_instructions['pouring_rouse']) && isset($existing_pouring_arr['pouring_rouse']))
+					$pouring_instructions['pouring_rouse'] = $existing_pouring_arr['pouring_rouse'];
+				if (!isset($pouring_instructions['pouring_notes']) && isset($existing_pouring_arr['pouring_notes']))
+					$pouring_instructions['pouring_notes'] = $existing_pouring_arr['pouring_notes'];
+			}
+		}
 		$brewPouring = json_encode($pouring_instructions);
 
 		if (isset($_POST['brewPackaging'])) $brewPackaging = sterilize($_POST['brewPackaging']);

--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -218,6 +218,39 @@ function in_string($haystack,$needle) {
 	if (strpos($haystack,$needle) !== false) return TRUE;
 }
 
+/**
+ * Translate a stored pouring instruction (brewPouring JSON: 'pouring').
+ * Maps cover the locale-neutral keys written by the entry forms. Values
+ * not in the map (e.g. legacy entries stored as translated literals in
+ * another locale, such as a Spanish 'Si') pass through unchanged and
+ * display as stored - intentional backwards compatibility for legacy
+ * data. Maps are defined in constants_post_lang.inc.php (after language
+ * load).
+ */
+function translate_pouring_value($value) {
+
+	global $pouring_translations;
+
+	if (isset($pouring_translations[$value])) return $pouring_translations[$value];
+	return $value;
+
+}
+
+/**
+ * Translate a stored rouse-yeast answer (brewPouring JSON:
+ * 'pouring_rouse'). Same map-and-fallback handling as
+ * translate_pouring_value(): values not in the map pass through
+ * unchanged and display as stored (backwards compatibility).
+ */
+function translate_pouring_rouse_value($value) {
+
+	global $pouring_rouse_translations;
+
+	if (isset($pouring_rouse_translations[$value])) return $pouring_rouse_translations[$value];
+	return $value;
+
+}
+
 function designations($judge_array,$display) {
 	$return = "";
 	$rank1 = explode(",",$judge_array);

--- a/output/pullsheets.output.php
+++ b/output/pullsheets.output.php
@@ -441,9 +441,9 @@ if ($go == "all_entry_info") {
 											if (!empty($row_entries['brewMead3'])) $table_flight_tbody .= "<strong>".$label_strength.":</strong> ".$row_entries['brewMead3']."<br>";
 											if ((!empty($row_entries['brewPouring'])) && ((!empty($row_entries['brewStyleType'])) && ($row_entries['brewStyleType'] == 1))) {
 												$pouring_arr = json_decode($row_entries['brewPouring'],true);
-												$table_flight_tbody .= "<strong>".$label_pouring.":</strong> ".translate_pouring_value($pouring_arr['pouring'])."<br>";
+												$table_flight_tbody .= "<strong>".$label_pouring.":</strong> ".h(translate_pouring_value($pouring_arr['pouring']))."<br>";
 												if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes']))) $table_flight_tbody .= "<strong>".$label_pouring_notes.":</strong> ".$pouring_arr['pouring_notes']."<br>";
-												$table_flight_tbody .= "<strong>".$label_rouse_yeast.":</strong> ".translate_pouring_rouse_value($pouring_arr['pouring_rouse'])."<br>";
+												$table_flight_tbody .= "<strong>".$label_rouse_yeast.":</strong> ".h(translate_pouring_rouse_value($pouring_arr['pouring_rouse']))."<br>";
 											}
 											if (!empty($row_entries['brewABV'])) $table_flight_tbody .= "<strong>".$label_abv.":</strong> ".$row_entries['brewABV']."<br>";
 											
@@ -900,9 +900,9 @@ if ($go == "mini_bos") {
 
 			if ((!empty($row_entries_mini['brewPouring'])) && ((!empty($row_entries_mini['brewStyleType'])) && ($row_entries_mini['brewStyleType'] == 1))) {
 				$pouring_arr = json_decode($row_entries_mini['brewPouring'],true);
-				$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".translate_pouring_value($pouring_arr['pouring'])."</li>";
+				$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".h(translate_pouring_value($pouring_arr['pouring']))."</li>";
 				if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes']))) $table_flight_tbody .= "<li><strong>".$label_pouring_notes.":</strong> ".$pouring_arr['pouring_notes']."</li>";
-				$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".translate_pouring_rouse_value($pouring_arr['pouring_rouse'])."</li>";
+				$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".h(translate_pouring_rouse_value($pouring_arr['pouring_rouse']))."</li>";
 			}
 
 			if (!empty($row_entries['brewStaffNotes'])) $table_flight_tbody .= "<li><strong>".$label_notes.":</strong> ".$row_entries['brewStaffNotes']."</li>";
@@ -1096,9 +1096,9 @@ if ($go == "judging_scores_bos") {
 
 						if ((!empty($row_bos['brewPouring'])) && ((!empty($row_bos['brewStyleType'])) && ($row_bos['brewStyleType'] == 1))) {
 							$pouring_arr = json_decode($row_bos['brewPouring'],true);
-							$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".translate_pouring_value($pouring_arr['pouring'])."</li>";
+							$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".h(translate_pouring_value($pouring_arr['pouring']))."</li>";
 							if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes']))) $table_flight_tbody .= "<li><strong>".$label_pouring_notes.":</strong> ".$pouring_arr['pouring_notes']."</li>";
-							$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".translate_pouring_rouse_value($pouring_arr['pouring_rouse'])."</li>";
+							$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".h(translate_pouring_rouse_value($pouring_arr['pouring_rouse']))."</li>";
 						}
 
 						if (!empty($row_bos['brewStaffNotes'])) $table_flight_tbody .= "<p><strong>".$label_notes.":</strong> ".$row_bos['brewStaffNotes']."</p>";
@@ -1328,9 +1328,9 @@ elseif (($go != "judging_scores_bos") && ($go != "mini_bos") && ($go != "all_ent
 
 									if ((!empty($row_entries['brewPouring'])) && ((!empty($row_entries['brewStyleType'])) && ($row_entries['brewStyleType'] == 1))) {
 										$pouring_arr = json_decode($row_entries['brewPouring'],true);
-										$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".translate_pouring_value($pouring_arr['pouring'])."</li>";
+										$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".h(translate_pouring_value($pouring_arr['pouring']))."</li>";
 										if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes']))) $table_flight_tbody .= "<li><strong>".$label_pouring_notes.":</strong> ".$pouring_arr['pouring_notes']."</li>";
-										$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".translate_pouring_rouse_value($pouring_arr['pouring_rouse'])."</li>";
+										$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".h(translate_pouring_rouse_value($pouring_arr['pouring_rouse']))."</li>";
 									}
 
 									if (!empty($row_entries['brewStaffNotes'])) $table_flight_tbody .= "<li><strong>".$label_notes.":</strong> ".$row_entries['brewStaffNotes']."</li>";
@@ -1553,9 +1553,9 @@ elseif (($go != "judging_scores_bos") && ($go != "mini_bos") && ($go != "all_ent
 
 									if ((!empty($row_entries['brewPouring'])) && ((!empty($row_entries['brewStyleType'])) && ($row_entries['brewStyleType'] == 1))) {
 										$pouring_arr = json_decode($row_entries['brewPouring'],true);
-										$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".translate_pouring_value($pouring_arr['pouring'])."</li>";
+										$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".h(translate_pouring_value($pouring_arr['pouring']))."</li>";
 										if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes']))) $table_flight_tbody .= "<li><strong>".$label_pouring_notes.":</strong> ".$pouring_arr['pouring_notes']."</li>";
-										$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".translate_pouring_rouse_value($pouring_arr['pouring_rouse'])."</li>";
+										$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".h(translate_pouring_rouse_value($pouring_arr['pouring_rouse']))."</li>";
 									}
 
 									if (!empty($row_entries['brewStaffNotes'])) $table_flight_tbody .= "<li><strong>".$label_notes.":</strong> ".$row_entries['brewStaffNotes']."</li>";
@@ -1785,9 +1785,9 @@ elseif (($go != "judging_scores_bos") && ($go != "mini_bos") && ($go != "all_ent
 
 											if ((!empty($row_entries['brewPouring'])) && ((!empty($row_entries['brewStyleType'])) && ($row_entries['brewStyleType'] == 1))) {
 												$pouring_arr = json_decode($row_entries['brewPouring'],true);
-												$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".translate_pouring_value($pouring_arr['pouring'])."</li>";
+												$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".h(translate_pouring_value($pouring_arr['pouring']))."</li>";
 												if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes']))) $table_flight_tbody .= "<li><strong>".$label_pouring_notes.":</strong> ".$pouring_arr['pouring_notes']."</li>";
-												$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".translate_pouring_rouse_value($pouring_arr['pouring_rouse'])."</li>";
+												$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".h(translate_pouring_rouse_value($pouring_arr['pouring_rouse']))."</li>";
 											}
 
 											if (!empty($row_entries['brewStaffNotes'])) $table_flight_tbody .= "<li><strong>".$label_notes.":</strong> ".$row_entries['brewStaffNotes']."</li>";
@@ -2023,9 +2023,9 @@ elseif (($go != "judging_scores_bos") && ($go != "mini_bos") && ($go != "all_ent
 
 									if ((!empty($row_entries['brewPouring'])) && ((!empty($row_entries['brewStyleType'])) && ($row_entries['brewStyleType'] == 1))) {
 										$pouring_arr = json_decode($row_entries['brewPouring'],true);
-										$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".translate_pouring_value($pouring_arr['pouring'])."</li>";
+										$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".h(translate_pouring_value($pouring_arr['pouring']))."</li>";
 										if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes']))) $table_flight_tbody .= "<li><strong>".$label_pouring_notes.":</strong> ".$pouring_arr['pouring_notes']."</li>";
-										$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".translate_pouring_rouse_value($pouring_arr['pouring_rouse'])."</li>";
+										$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".h(translate_pouring_rouse_value($pouring_arr['pouring_rouse']))."</li>";
 									}
 
 									if (!empty($row_entries['brewStaffNotes'])) $table_flight_tbody .= "<li><strong>".$label_notes.":</strong> ".$row_entries['brewStaffNotes']."</li>";
@@ -2325,9 +2325,9 @@ elseif (($go != "judging_scores_bos") && ($go != "mini_bos") && ($go != "all_ent
 
 								if ((!empty($row_entries['brewPouring'])) && ((!empty($row_entries['brewStyleType'])) && ($row_entries['brewStyleType'] == 1))) {
 									$pouring_arr = json_decode($row_entries['brewPouring'],true);
-									$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".translate_pouring_value($pouring_arr['pouring'])."</li>";
+									$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".h(translate_pouring_value($pouring_arr['pouring']))."</li>";
 									if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes']))) $table_flight_tbody .= "<li><strong>".$label_pouring_notes.":</strong> ".$pouring_arr['pouring_notes']."</li>";
-									$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".translate_pouring_rouse_value($pouring_arr['pouring_rouse'])."</li>";
+									$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".h(translate_pouring_rouse_value($pouring_arr['pouring_rouse']))."</li>";
 								}
 
 								if (!empty($row_entries['brewStaffNotes'])) $table_flight_tbody .= "<li><strong>".$label_notes.":</strong> ".$row_entries['brewStaffNotes']."</li>";

--- a/output/pullsheets.output.php
+++ b/output/pullsheets.output.php
@@ -441,9 +441,9 @@ if ($go == "all_entry_info") {
 											if (!empty($row_entries['brewMead3'])) $table_flight_tbody .= "<strong>".$label_strength.":</strong> ".$row_entries['brewMead3']."<br>";
 											if ((!empty($row_entries['brewPouring'])) && ((!empty($row_entries['brewStyleType'])) && ($row_entries['brewStyleType'] == 1))) {
 												$pouring_arr = json_decode($row_entries['brewPouring'],true);
-												$table_flight_tbody .= "<strong>".$label_pouring.":</strong> ".$pouring_arr['pouring']."<br>";
+												$table_flight_tbody .= "<strong>".$label_pouring.":</strong> ".translate_pouring_value($pouring_arr['pouring'])."<br>";
 												if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes']))) $table_flight_tbody .= "<strong>".$label_pouring_notes.":</strong> ".$pouring_arr['pouring_notes']."<br>";
-												$table_flight_tbody .= "<strong>".$label_rouse_yeast.":</strong> ".$pouring_arr['pouring_rouse']."<br>";
+												$table_flight_tbody .= "<strong>".$label_rouse_yeast.":</strong> ".translate_pouring_rouse_value($pouring_arr['pouring_rouse'])."<br>";
 											}
 											if (!empty($row_entries['brewABV'])) $table_flight_tbody .= "<strong>".$label_abv.":</strong> ".$row_entries['brewABV']."<br>";
 											
@@ -900,9 +900,9 @@ if ($go == "mini_bos") {
 
 			if ((!empty($row_entries_mini['brewPouring'])) && ((!empty($row_entries_mini['brewStyleType'])) && ($row_entries_mini['brewStyleType'] == 1))) {
 				$pouring_arr = json_decode($row_entries_mini['brewPouring'],true);
-				$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".$pouring_arr['pouring']."</li>";
+				$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".translate_pouring_value($pouring_arr['pouring'])."</li>";
 				if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes']))) $table_flight_tbody .= "<li><strong>".$label_pouring_notes.":</strong> ".$pouring_arr['pouring_notes']."</li>";
-				$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".$pouring_arr['pouring_rouse']."</li>";
+				$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".translate_pouring_rouse_value($pouring_arr['pouring_rouse'])."</li>";
 			}
 
 			if (!empty($row_entries['brewStaffNotes'])) $table_flight_tbody .= "<li><strong>".$label_notes.":</strong> ".$row_entries['brewStaffNotes']."</li>";
@@ -1096,9 +1096,9 @@ if ($go == "judging_scores_bos") {
 
 						if ((!empty($row_bos['brewPouring'])) && ((!empty($row_bos['brewStyleType'])) && ($row_bos['brewStyleType'] == 1))) {
 							$pouring_arr = json_decode($row_bos['brewPouring'],true);
-							$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".$pouring_arr['pouring']."</li>";
+							$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".translate_pouring_value($pouring_arr['pouring'])."</li>";
 							if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes']))) $table_flight_tbody .= "<li><strong>".$label_pouring_notes.":</strong> ".$pouring_arr['pouring_notes']."</li>";
-							$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".$pouring_arr['pouring_rouse']."</li>";
+							$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".translate_pouring_rouse_value($pouring_arr['pouring_rouse'])."</li>";
 						}
 
 						if (!empty($row_bos['brewStaffNotes'])) $table_flight_tbody .= "<p><strong>".$label_notes.":</strong> ".$row_bos['brewStaffNotes']."</p>";
@@ -1328,9 +1328,9 @@ elseif (($go != "judging_scores_bos") && ($go != "mini_bos") && ($go != "all_ent
 
 									if ((!empty($row_entries['brewPouring'])) && ((!empty($row_entries['brewStyleType'])) && ($row_entries['brewStyleType'] == 1))) {
 										$pouring_arr = json_decode($row_entries['brewPouring'],true);
-										$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".$pouring_arr['pouring']."</li>";
+										$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".translate_pouring_value($pouring_arr['pouring'])."</li>";
 										if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes']))) $table_flight_tbody .= "<li><strong>".$label_pouring_notes.":</strong> ".$pouring_arr['pouring_notes']."</li>";
-										$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".$pouring_arr['pouring_rouse']."</li>";
+										$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".translate_pouring_rouse_value($pouring_arr['pouring_rouse'])."</li>";
 									}
 
 									if (!empty($row_entries['brewStaffNotes'])) $table_flight_tbody .= "<li><strong>".$label_notes.":</strong> ".$row_entries['brewStaffNotes']."</li>";
@@ -1553,9 +1553,9 @@ elseif (($go != "judging_scores_bos") && ($go != "mini_bos") && ($go != "all_ent
 
 									if ((!empty($row_entries['brewPouring'])) && ((!empty($row_entries['brewStyleType'])) && ($row_entries['brewStyleType'] == 1))) {
 										$pouring_arr = json_decode($row_entries['brewPouring'],true);
-										$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".$pouring_arr['pouring']."</li>";
+										$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".translate_pouring_value($pouring_arr['pouring'])."</li>";
 										if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes']))) $table_flight_tbody .= "<li><strong>".$label_pouring_notes.":</strong> ".$pouring_arr['pouring_notes']."</li>";
-										$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".$pouring_arr['pouring_rouse']."</li>";
+										$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".translate_pouring_rouse_value($pouring_arr['pouring_rouse'])."</li>";
 									}
 
 									if (!empty($row_entries['brewStaffNotes'])) $table_flight_tbody .= "<li><strong>".$label_notes.":</strong> ".$row_entries['brewStaffNotes']."</li>";
@@ -1785,9 +1785,9 @@ elseif (($go != "judging_scores_bos") && ($go != "mini_bos") && ($go != "all_ent
 
 											if ((!empty($row_entries['brewPouring'])) && ((!empty($row_entries['brewStyleType'])) && ($row_entries['brewStyleType'] == 1))) {
 												$pouring_arr = json_decode($row_entries['brewPouring'],true);
-												$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".$pouring_arr['pouring']."</li>";
+												$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".translate_pouring_value($pouring_arr['pouring'])."</li>";
 												if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes']))) $table_flight_tbody .= "<li><strong>".$label_pouring_notes.":</strong> ".$pouring_arr['pouring_notes']."</li>";
-												$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".$pouring_arr['pouring_rouse']."</li>";
+												$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".translate_pouring_rouse_value($pouring_arr['pouring_rouse'])."</li>";
 											}
 
 											if (!empty($row_entries['brewStaffNotes'])) $table_flight_tbody .= "<li><strong>".$label_notes.":</strong> ".$row_entries['brewStaffNotes']."</li>";
@@ -2023,9 +2023,9 @@ elseif (($go != "judging_scores_bos") && ($go != "mini_bos") && ($go != "all_ent
 
 									if ((!empty($row_entries['brewPouring'])) && ((!empty($row_entries['brewStyleType'])) && ($row_entries['brewStyleType'] == 1))) {
 										$pouring_arr = json_decode($row_entries['brewPouring'],true);
-										$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".$pouring_arr['pouring']."</li>";
+										$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".translate_pouring_value($pouring_arr['pouring'])."</li>";
 										if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes']))) $table_flight_tbody .= "<li><strong>".$label_pouring_notes.":</strong> ".$pouring_arr['pouring_notes']."</li>";
-										$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".$pouring_arr['pouring_rouse']."</li>";
+										$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".translate_pouring_rouse_value($pouring_arr['pouring_rouse'])."</li>";
 									}
 
 									if (!empty($row_entries['brewStaffNotes'])) $table_flight_tbody .= "<li><strong>".$label_notes.":</strong> ".$row_entries['brewStaffNotes']."</li>";
@@ -2325,9 +2325,9 @@ elseif (($go != "judging_scores_bos") && ($go != "mini_bos") && ($go != "all_ent
 
 								if ((!empty($row_entries['brewPouring'])) && ((!empty($row_entries['brewStyleType'])) && ($row_entries['brewStyleType'] == 1))) {
 									$pouring_arr = json_decode($row_entries['brewPouring'],true);
-									$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".$pouring_arr['pouring']."</li>";
+									$table_flight_tbody .= "<li><strong>".$label_pouring.":</strong> ".translate_pouring_value($pouring_arr['pouring'])."</li>";
 									if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes']))) $table_flight_tbody .= "<li><strong>".$label_pouring_notes.":</strong> ".$pouring_arr['pouring_notes']."</li>";
-									$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".$pouring_arr['pouring_rouse']."</li>";
+									$table_flight_tbody .= "<li><strong>".$label_rouse_yeast.":</strong> ".translate_pouring_rouse_value($pouring_arr['pouring_rouse'])."</li>";
 								}
 
 								if (!empty($row_entries['brewStaffNotes'])) $table_flight_tbody .= "<li><strong>".$label_notes.":</strong> ".$row_entries['brewStaffNotes']."</li>";

--- a/pub/brew.pub.php
+++ b/pub/brew.pub.php
@@ -868,15 +868,15 @@ if ($_SESSION['prefsStyleSet'] == "NWCiderCup") {
 		    <label for="brewPouringInst" class="col-xs-12 col-sm-3 col-lg-2 col-form-label"><strong><?php echo $label_pouring; ?></strong></label>
 		    <div class="col-xs-12 col-sm-9 col-lg-10">
 		        <div class="form-check form-check-inline">
-                	<input class="form-check-input" type="radio" name="brewPouringInst" id="brewPouringInst-Fast" value="<?php echo $label_fast; ?>" <?php if (($action == "edit") && ($pouring_arr['pouring'] == $label_fast)) echo "CHECKED"; ?>>
+                	<input class="form-check-input" type="radio" name="brewPouringInst" id="brewPouringInst-Fast" value="fast" <?php if (($action == "edit") && (($pouring_arr['pouring'] == "fast") || ($pouring_arr['pouring'] == $label_fast))) echo "CHECKED"; ?>>
                 	<label class="form-check-label" for="brewPouringInst-Fast"><?php echo $label_fast; ?></label>
-                </div>
-                <div class="form-check form-check-inline">
-                	<input class="form-check-input" type="radio" name="brewPouringInst" id="brewPouringInst-Normal" value="<?php echo $label_normal; ?>" <?php if ($action == "add") echo "CHECKED"; if (($action == "edit") && ($pouring_arr['pouring'] == $label_normal)) echo "CHECKED"; ?>>
+                	</div>
+                	<div class="form-check form-check-inline">
+                	<input class="form-check-input" type="radio" name="brewPouringInst" id="brewPouringInst-Normal" value="normal" <?php if ($action == "add") echo "CHECKED"; if (($action == "edit") && (($pouring_arr['pouring'] == "normal") || ($pouring_arr['pouring'] == $label_normal))) echo "CHECKED"; ?>>
                 	<label class="form-check-label" for="brewPouringInst-Normal"><?php echo $label_normal; ?></label>
-                </div>
-                <div class="form-check form-check-inline">
-                	<input class="form-check-input" type="radio" name="brewPouringInst" id="brewPouringInst-Slow" value="<?php echo $label_slow; ?>" <?php if (($action == "edit") && ($pouring_arr['pouring'] == $label_slow)) echo "CHECKED"; ?>>
+                	</div>
+                	<div class="form-check form-check-inline">
+                	<input class="form-check-input" type="radio" name="brewPouringInst" id="brewPouringInst-Slow" value="slow" <?php if (($action == "edit") && (($pouring_arr['pouring'] == "slow") || ($pouring_arr['pouring'] == $label_slow))) echo "CHECKED"; ?>>
                 	<label class="form-check-label" for="brewPouringInst-Slow"><?php echo $label_slow; ?></label>
                 </div>
                 <div>
@@ -889,11 +889,11 @@ if ($_SESSION['prefsStyleSet'] == "NWCiderCup") {
 		    <label for="brewPouringRouse" class="col-xs-12 col-sm-3 col-lg-2 col-form-label"><strong><?php echo $label_rouse_yeast; ?></strong></label>
 		    <div class="col-xs-12 col-sm-9 col-lg-10">
 		    	<div class="form-check form-check-inline">
-                	<input class="form-check-input" type="radio" name="brewPouringRouse" id="brewPouringRouse-Yes" value="<?php echo $label_yes; ?>" <?php if (($action == "edit") && ($pouring_arr['pouring_rouse'] == $label_yes)) echo "CHECKED"; ?>>
+                	<input class="form-check-input" type="radio" name="brewPouringRouse" id="brewPouringRouse-Yes" value="yes" <?php if (($action == "edit") && (($pouring_arr['pouring_rouse'] == "yes") || ($pouring_arr['pouring_rouse'] == $label_yes))) echo "CHECKED"; ?>>
                 	<label class="form-check-label" for="brewPouringRouse-Yes"><?php echo $label_yes; ?></label>
-                </div>
-                <div class="form-check form-check-inline">
-                	<input class="form-check-input" type="radio" name="brewPouringRouse" id="brewPouringRouse-No" value="<?php echo $label_no; ?>" <?php if (($action == "edit") && ($pouring_arr['pouring_rouse'] == $label_no)) echo "CHECKED"; ?>>
+                	</div>
+                	<div class="form-check form-check-inline">
+                	<input class="form-check-input" type="radio" name="brewPouringRouse" id="brewPouringRouse-No" value="no" <?php if (($action == "edit") && (($pouring_arr['pouring_rouse'] == "no") || ($pouring_arr['pouring_rouse'] == $label_no))) echo "CHECKED"; ?>>
                 	<label class="form-check-label" for="brewPouringRouse-No"><?php echo $label_no; ?></label>
                 </div>
                 <div>

--- a/pub/brewer_entries.pub.php
+++ b/pub/brewer_entries.pub.php
@@ -222,9 +222,9 @@ if ($totalRows_log > 0) {
 
 		if ((!empty($row_log['brewPouring'])) && ((!empty($row_log['brewStyleType'])) && ($row_log['brewStyleType'] == 1))) {
 			$pouring_arr = json_decode($row_log['brewPouring'],true);
-			$required_info .= "<li><strong>".$label_pouring.":</strong> ".$pouring_arr['pouring']."</li>";
+			$required_info .= "<li><strong>".$label_pouring.":</strong> ".translate_pouring_value($pouring_arr['pouring'])."</li>";
 			if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes']))) $required_info .= "<li><strong>".$label_pouring_notes.":</strong> ".$pouring_arr['pouring_notes']."</li>";
-			$required_info .= "<li><strong>".$label_rouse_yeast.":</strong> ".$pouring_arr['pouring_rouse']."</li>";
+			$required_info .= "<li><strong>".$label_rouse_yeast.":</strong> ".translate_pouring_rouse_value($pouring_arr['pouring_rouse'])."</li>";
 		}
 
 		if (!empty($row_log['brewPossAllergens'])) {

--- a/pub/brewer_entries.pub.php
+++ b/pub/brewer_entries.pub.php
@@ -222,9 +222,9 @@ if ($totalRows_log > 0) {
 
 		if ((!empty($row_log['brewPouring'])) && ((!empty($row_log['brewStyleType'])) && ($row_log['brewStyleType'] == 1))) {
 			$pouring_arr = json_decode($row_log['brewPouring'],true);
-			$required_info .= "<li><strong>".$label_pouring.":</strong> ".translate_pouring_value($pouring_arr['pouring'])."</li>";
+			$required_info .= "<li><strong>".$label_pouring.":</strong> ".h(translate_pouring_value($pouring_arr['pouring']))."</li>";
 			if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes']))) $required_info .= "<li><strong>".$label_pouring_notes.":</strong> ".$pouring_arr['pouring_notes']."</li>";
-			$required_info .= "<li><strong>".$label_rouse_yeast.":</strong> ".translate_pouring_rouse_value($pouring_arr['pouring_rouse'])."</li>";
+			$required_info .= "<li><strong>".$label_rouse_yeast.":</strong> ".h(translate_pouring_rouse_value($pouring_arr['pouring_rouse']))."</li>";
 		}
 
 		if (!empty($row_log['brewPossAllergens'])) {

--- a/pub/eval_dashboard.pub.php
+++ b/pub/eval_dashboard.pub.php
@@ -388,9 +388,9 @@ if ($totalRows_table_assignments > 0) {
 
 							if (!empty($row_entries['brewPouring'])) {
 								$pouring_arr = json_decode($row_entries['brewPouring'],true);
-								$pouring_display .= "<li><strong>".$label_pouring.":</strong> ".$pouring_arr['pouring']."</li>";
+								$pouring_display .= "<li><strong>".$label_pouring.":</strong> ".translate_pouring_value($pouring_arr['pouring'])."</li>";
 								if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes']))) $pouring_display .= "<li><strong>".$label_pouring_notes.":</strong> ".$pouring_arr['pouring_notes']."</li>";
-								$pouring_display .= "<li><strong>".$label_rouse_yeast.":</strong> ".$pouring_arr['pouring_rouse']."</li>";
+								$pouring_display .= "<li><strong>".$label_rouse_yeast.":</strong> ".translate_pouring_rouse_value($pouring_arr['pouring_rouse'])."</li>";
 								unset($pouring_arr);
 							}
 

--- a/pub/eval_dashboard.pub.php
+++ b/pub/eval_dashboard.pub.php
@@ -388,9 +388,9 @@ if ($totalRows_table_assignments > 0) {
 
 							if (!empty($row_entries['brewPouring'])) {
 								$pouring_arr = json_decode($row_entries['brewPouring'],true);
-								$pouring_display .= "<li><strong>".$label_pouring.":</strong> ".translate_pouring_value($pouring_arr['pouring'])."</li>";
+								$pouring_display .= "<li><strong>".$label_pouring.":</strong> ".h(translate_pouring_value($pouring_arr['pouring']))."</li>";
 								if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes']))) $pouring_display .= "<li><strong>".$label_pouring_notes.":</strong> ".$pouring_arr['pouring_notes']."</li>";
-								$pouring_display .= "<li><strong>".$label_rouse_yeast.":</strong> ".translate_pouring_rouse_value($pouring_arr['pouring_rouse'])."</li>";
+								$pouring_display .= "<li><strong>".$label_rouse_yeast.":</strong> ".h(translate_pouring_rouse_value($pouring_arr['pouring_rouse']))."</li>";
 								unset($pouring_arr);
 							}
 

--- a/pub/eval_scoresheet.pub.php
+++ b/pub/eval_scoresheet.pub.php
@@ -510,7 +510,7 @@ if ($entry_found) {
 
     $entry_info_html .= "<div class=\"row mb-3\">";
     $entry_info_html .= "<div class=\"col-12 col-lg-3 col-md-4 col-sm-4\"><strong>".$label_pouring."</strong></div>";
-    $entry_info_html .= "<div class=\"col-12 col-lg-9 col-md-8 col-sm-8\">".translate_pouring_value($pouring_arr['pouring'])."</div>";
+    $entry_info_html .= "<div class=\"col-12 col-lg-9 col-md-8 col-sm-8\">".h(translate_pouring_value($pouring_arr['pouring']))."</div>";
     $entry_info_html .= "</div>";
 
     if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes'])))  {
@@ -522,7 +522,7 @@ if ($entry_found) {
 
     $entry_info_html .= "<div class=\"row mb-3\">";
     $entry_info_html .= "<div class=\"col-12 col-lg-3 col-md-4 col-sm-4\"><strong>".$label_rouse_yeast."</strong></div>";
-    $entry_info_html .= "<div class=\"col-12 col-lg-9 col-md-8 col-sm-8\">".translate_pouring_rouse_value($pouring_arr['pouring_rouse'])."</div>";
+    $entry_info_html .= "<div class=\"col-12 col-lg-9 col-md-8 col-sm-8\">".h(translate_pouring_rouse_value($pouring_arr['pouring_rouse']))."</div>";
     $entry_info_html .= "</div>";
 
   }

--- a/pub/eval_scoresheet.pub.php
+++ b/pub/eval_scoresheet.pub.php
@@ -510,7 +510,7 @@ if ($entry_found) {
 
     $entry_info_html .= "<div class=\"row mb-3\">";
     $entry_info_html .= "<div class=\"col-12 col-lg-3 col-md-4 col-sm-4\"><strong>".$label_pouring."</strong></div>";
-    $entry_info_html .= "<div class=\"col-12 col-lg-9 col-md-8 col-sm-8\">".$pouring_arr['pouring']."</div>";
+    $entry_info_html .= "<div class=\"col-12 col-lg-9 col-md-8 col-sm-8\">".translate_pouring_value($pouring_arr['pouring'])."</div>";
     $entry_info_html .= "</div>";
 
     if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes'])))  {
@@ -522,7 +522,7 @@ if ($entry_found) {
 
     $entry_info_html .= "<div class=\"row mb-3\">";
     $entry_info_html .= "<div class=\"col-12 col-lg-3 col-md-4 col-sm-4\"><strong>".$label_rouse_yeast."</strong></div>";
-    $entry_info_html .= "<div class=\"col-12 col-lg-9 col-md-8 col-sm-8\">".$pouring_arr['pouring_rouse']."</div>";
+    $entry_info_html .= "<div class=\"col-12 col-lg-9 col-md-8 col-sm-8\">".translate_pouring_rouse_value($pouring_arr['pouring_rouse'])."</div>";
     $entry_info_html .= "</div>";
 
   }

--- a/sections/brew.sec.php
+++ b/sections/brew.sec.php
@@ -769,13 +769,13 @@ echo $add_edit_entry_modals;
 		    <div class="col-lg-6 col-md-6 col-sm-8 col-xs-12">
 		        <div class="input-group" id="brewPouringInst">
 				    <label class="radio-inline">
-				      <input name="brewPouringInst" type="radio" id="brewPouringInst-Fast" value="<?php echo $label_fast; ?>" <?php if (($action == "edit") && ($pouring_arr['pouring'] == $label_fast)) echo "CHECKED"; ?>> <?php echo $label_fast; ?>
+				      <input name="brewPouringInst" type="radio" id="brewPouringInst-Fast" value="fast" <?php if (($action == "edit") && (($pouring_arr['pouring'] == "fast") || ($pouring_arr['pouring'] == $label_fast))) echo "CHECKED"; ?>> <?php echo $label_fast; ?>
 				    </label>
 				    <label class="radio-inline">
-				      <input name="brewPouringInst" type="radio" id="brewPouringInst-Normal" value="<?php echo $label_normal; ?>" <?php if ($action == "add") echo "CHECKED"; if (($action == "edit") && ($pouring_arr['pouring'] == $label_normal)) echo "CHECKED"; ?>> <?php echo $label_normal; ?>
+				      <input name="brewPouringInst" type="radio" id="brewPouringInst-Normal" value="normal" <?php if ($action == "add") echo "CHECKED"; if (($action == "edit") && (($pouring_arr['pouring'] == "normal") || ($pouring_arr['pouring'] == $label_normal))) echo "CHECKED"; ?>> <?php echo $label_normal; ?>
 				    </label>
 				    <label class="radio-inline">
-				      <input name="brewPouringInst" type="radio" id="brewPouringInst-Slow" value="<?php echo $label_slow; ?>" <?php if (($action == "edit") && ($pouring_arr['pouring'] == $label_slow)) echo "CHECKED"; ?>> <?php echo $label_slow; ?>
+				      <input name="brewPouringInst" type="radio" id="brewPouringInst-Slow" value="slow" <?php if (($action == "edit") && (($pouring_arr['pouring'] == "slow") || ($pouring_arr['pouring'] == $label_slow))) echo "CHECKED"; ?>> <?php echo $label_slow; ?>
 				    </label>
 				</div>
 				<div class="help-block with-errors"></div>
@@ -787,10 +787,10 @@ echo $add_edit_entry_modals;
 		    <div class="col-lg-6 col-md-6 col-sm-8 col-xs-12">
 		        <div class="input-group" id="brewPouringRouse">
 				    <label class="radio-inline">
-				      <input name="brewPouringRouse" type="radio" id="brewPouringRouse-Yes" value="<?php echo $label_yes; ?>" <?php if (($action == "edit") && ($pouring_arr['pouring_rouse'] == $label_yes)) echo "CHECKED"; ?>> <?php echo $label_yes; ?>
+				      <input name="brewPouringRouse" type="radio" id="brewPouringRouse-Yes" value="yes" <?php if (($action == "edit") && (($pouring_arr['pouring_rouse'] == "yes") || ($pouring_arr['pouring_rouse'] == $label_yes))) echo "CHECKED"; ?>> <?php echo $label_yes; ?>
 				    </label>
 				    <label class="radio-inline">
-				      <input name="brewPouringRouse" type="radio" id="brewPouringRouse-No" value="<?php echo $label_no; ?>" <?php if ($action == "add") echo "CHECKED"; if (($action == "edit") && ($pouring_arr['pouring_rouse'] == $label_no)) echo "CHECKED"; ?>> <?php echo $label_no; ?>
+				      <input name="brewPouringRouse" type="radio" id="brewPouringRouse-No" value="no" <?php if (($action == "edit") && (($pouring_arr['pouring_rouse'] == "no") || ($pouring_arr['pouring_rouse'] == $label_no))) echo "CHECKED"; ?>> <?php echo $label_no; ?>
 				    </label>
 				</div>
 				<div class="help-block with-errors"></div>

--- a/sections/brewer_entries.sec.php
+++ b/sections/brewer_entries.sec.php
@@ -217,9 +217,9 @@ if ($totalRows_log > 0) {
 
 		if ((!empty($row_log['brewPouring'])) && ((!empty($row_log['brewStyleType'])) && ($row_log['brewStyleType'] == 1))) {
 			$pouring_arr = json_decode($row_log['brewPouring'],true);
-			$required_info .= "<li><strong>".$label_pouring.":</strong> ".$pouring_arr['pouring']."</li>";
+			$required_info .= "<li><strong>".$label_pouring.":</strong> ".h(translate_pouring_value($pouring_arr['pouring']))."</li>";
 			if ((isset($pouring_arr['pouring_notes'])) && (!empty($pouring_arr['pouring_notes']))) $required_info .= "<li><strong>".$label_pouring_notes.":</strong> ".$pouring_arr['pouring_notes']."</li>";
-			$required_info .= "<li><strong>".$label_rouse_yeast.":</strong> ".$pouring_arr['pouring_rouse']."</li>";
+			$required_info .= "<li><strong>".$label_rouse_yeast.":</strong> ".h(translate_pouring_rouse_value($pouring_arr['pouring_rouse']))."</li>";
 		}
 
 		if (!empty($row_log['brewPossAllergens'])) {


### PR DESCRIPTION
Another edge case here for multiple language implementations. 

The Entry Form "Pouring Instructions" radio buttons store the translated label as the value (value="<?php echo $label_fast; ?>"), so brewPouring JSON contained locale-dependent text that is stored in the database: a Korean entrant's entry stored '보통'/'아니오', an English entrant's 'Normal'/'No'. Display pages echoed the stored value raw, so entry pouring instructions will also be displayed in the language used by the Entrant.

- Entry forms (brew.pub.php, legacy brew.sec.php) now store locale-neutral keys: fast/normal/slow and yes/no. Edit forms match either the key or the legacy literal so existing entries still show the correct radio pre-selected.
- New translate_pouring_value() / translate_pouring_rouse_value() in lib/common.lib.php map the new keys to the current language's decode (maps in constants_post_lang.inc.php, following the $style_types_translations pattern). Values not in the map pass through unchanged and display as stored (intentional backwards compatibility with legacy locale-dependent data; no data migration needed).
- Applied on the Account entries page, Eval dashboard, Eval scoresheets, and Pull sheets.