### PR TITLE
Render entry labels in the site-wide default language

### DIFF
--- a/includes/db/default_language.db.php
+++ b/includes/db/default_language.db.php
@@ -20,7 +20,8 @@ if (!function_exists("get_default_language")) {
         static $cached = NULL;
         if ($cached !== NULL) return $cached;
 
-        $row = $db_conn->where("id", 1)->getOne($prefix."preferences", "prefsLanguage");
+        $db_conn->where("id", 1);
+        $row = $db_conn->getOne($prefix."preferences", "prefsLanguage");
         if (($db_conn->count == 0) || (empty($row['prefsLanguage']))) {
             $cached = array('lang' => 'en-US', 'folder' => 'en');
             return $cached;

--- a/includes/db/default_language.db.php
+++ b/includes/db/default_language.db.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Module:      default_language.db.php
+ * Description: Resolve the site-wide default language from the DB.
+ *
+ * Entry labels must be uniform regardless of which language the
+ * requesting user has chosen in the UI, so labels are always rendered in
+ * the site default. This helper reads prefsLanguage (and derives the
+ * folder) straight from the preferences table.
+ */
+
+if (!function_exists("get_default_language")) {
+
+    /**
+     * Returns array('lang' => 'ko-KR', 'folder' => 'ko') for the site
+     * default language, or NULL if unavailable.
+     */
+    function get_default_language() {
+        global $db_conn, $prefix;
+        static $cached = NULL;
+        if ($cached !== NULL) return $cached;
+
+        $row = $db_conn->where("id", 1)->getOne($prefix."preferences", "prefsLanguage");
+        if (($db_conn->count == 0) || (empty($row['prefsLanguage']))) {
+            $cached = array('lang' => 'en-US', 'folder' => 'en');
+            return $cached;
+        }
+
+        $lang = $row['prefsLanguage'];
+        // Legacy "English" value normalization (same as language.lang.php)
+        if (strtolower($lang) == "english") $lang = "en-US";
+        $parts = explode("-", $lang);
+        $cached = array('lang' => $lang, 'folder' => strtolower($parts[0]));
+        return $cached;
+    }
+
+}
+?>

--- a/includes/output.inc.php
+++ b/includes/output.inc.php
@@ -15,8 +15,38 @@ ini_set('display_errors', '1');
 require ('../paths.php');
 require (CONFIG.'bootstrap.php');
 require (INCLUDES.'url_variables.inc.php');
+
+/**
+ * Entry labels must be uniform regardless of the requesting user's UI
+ * language choice, so labels always render in the site-wide default
+ * language (privacy: nobody should be able to identify the entrant's
+ * language from the printed label). Swap the language session vars to
+ * the default for the duration of this output render, then restore them
+ * afterwards. The userLanguage cookie is neutralized too, because
+ * language.lang.php re-applies it below this swap point.
+ * Scoresheets and other output keep the user's chosen language.
+ */
+if (($section == "entry-form") || ($section == "entry-form-multi")) {
+    include (DB.'default_language.db.php');
+    $default_lang_info = get_default_language();
+    $saved_prefsLanguage = isset($_SESSION['prefsLanguage']) ? $_SESSION['prefsLanguage'] : "";
+    $saved_prefsLanguageFolder = isset($_SESSION['prefsLanguageFolder']) ? $_SESSION['prefsLanguageFolder'] : "";
+    $saved_userLanguageCookie = isset($_COOKIE['userLanguage']) ? $_COOKIE['userLanguage'] : "";
+    $_SESSION['prefsLanguage'] = $default_lang_info['lang'];
+    $_SESSION['prefsLanguageFolder'] = $default_lang_info['folder'];
+    // Neutralize the cookie so language.lang.php's per-session override
+    // doesn't re-apply the user's language after our swap.
+    unset($_COOKIE['userLanguage']);
+}
+
 require (LANG.'language.lang.php');
 require (INCLUDES.'constants_post_lang.inc.php');
+
+// Restore the user's own language choice after the label output completes
+if ((($section == "entry-form") || ($section == "entry-form-multi")) && (isset($saved_prefsLanguage))) {
+    if ($saved_prefsLanguage !== "") $_SESSION['prefsLanguage'] = $saved_prefsLanguage; else unset($_SESSION['prefsLanguage']);
+    if ($saved_prefsLanguageFolder !== "") $_SESSION['prefsLanguageFolder'] = $saved_prefsLanguageFolder; else unset($_SESSION['prefsLanguageFolder']);
+}
 
 function convert_to_entities($input) {
     $output = preg_replace_callback("/(&#[0-9]+;)/", function($m) { 


### PR DESCRIPTION
Another edge case for multi-language implementations.

Entry labels identify entries physically when shipped or dropped off, and are handled by competition Staff and Judges. Rendering them in the requesting user's personal UI language lets the Staff/Judge identify which language the entrant speaks from the printed label. This information should not be exposed and it makes labels inconsistent within a competition.

Render entry labels (output.inc.php sections entry-form and entry-form-multi) in the site-wide default language (prefsLanguage from the preferences table), regardless of the requesting user's personal language choice:

- New get_default_language() helper (includes/db/default_language.db.php) resolves the default from the DB, with legacy 'English' value normalization.
- output.inc.php swaps the language session vars to the default for the duration of the label render and restores the user's own choice afterwards, so nothing bleeds into their session.
- The userLanguage cookie is neutralized during the render because language.lang.php re-applies it after the swap point.

Scoresheets and all other Output keep the requesting user's chosen language: judges and entrants read those on screen in their own language.