### PR TITLE
feat(account): link judge coordinator and organizer emails on My Account

### DIFF
--- a/lib/common.lib.php
+++ b/lib/common.lib.php
@@ -5519,4 +5519,44 @@ function validate_bjcp_id($input) {
 	else return TRUE;
 }
 
+/**
+ * Build mailto: links for the competition's judge coordinator and organizer contacts.
+ *
+ * Returns an empty string unless the contact form is disabled and the contact list is shown
+ * (prefsContact == "N") - the same condition under which the Contact page already publishes
+ * these addresses. Roles are not stored in their own column, so contacts are matched on the
+ * free-text contactPosition. Used on the My Account page for participants who are assigned to
+ * a table and therefore cannot change their own judge/steward role. See GitHub issue #1752.
+ */
+function coordinator_mailto_links($db_conn, $prefix) {
+
+	if ((!isset($_SESSION['prefsContact'])) || ($_SESSION['prefsContact'] != "N")) return "";
+
+	$db_conn->orderBy("contactLastName", "ASC");
+	$db_conn->orderBy("contactPosition", "ASC");
+	$rows_contact = $db_conn->get($prefix."contacts");
+
+	$links = array();
+
+	if (!empty($rows_contact)) {
+
+		foreach ($rows_contact as $row_contact) {
+
+			$position = (string) $row_contact['contactPosition'];
+			if ((stripos($position, "coordinator") === FALSE) && (stripos($position, "organizer") === FALSE) && (stripos($position, "organiser") === FALSE)) continue;
+			if (empty($row_contact['contactEmail'])) continue;
+
+			$name = trim($row_contact['contactFirstName']." ".$row_contact['contactLastName']);
+			if ($name != "") $name .= ", ";
+
+			$links[] = sprintf("<a href='mailto:%s'>%s</a>", h($row_contact['contactEmail']), h($name.$position));
+
+		}
+
+	}
+
+	return implode(", ", $links);
+
+}
+
 ?>

--- a/pub/brewer_info.pub.php
+++ b/pub/brewer_info.pub.php
@@ -246,11 +246,20 @@ foreach ($a as $value) {
 
 }
 
-if ($_SESSION['jPrefsTablePlanning'] == 0) {
-	if ($action == "print") $table_assign_judge = table_assignments($_SESSION['user_id'],"J",$_SESSION['prefsTimeZone'],$_SESSION['prefsDateFormat'],$_SESSION['prefsTimeFormat'],1);
-	else $table_assign_judge = table_assignments($_SESSION['user_id'],"J",$_SESSION['prefsTimeZone'],$_SESSION['prefsDateFormat'],$_SESSION['prefsTimeFormat'],0);
-	if ($action == "print") $table_assign_steward = table_assignments($_SESSION['user_id'],"S",$_SESSION['prefsTimeZone'],$_SESSION['prefsDateFormat'],$_SESSION['prefsTimeFormat'],1);
-	else $table_assign_steward = table_assignments($_SESSION['user_id'],"S",$_SESSION['prefsTimeZone'],$_SESSION['prefsDateFormat'],$_SESSION['prefsTimeFormat'],0);
+// Resolve table assignments in both Tables Planning and Competition Mode so an assigned
+// participant can see why their judge/steward fields are locked. This previously ran only
+// in Competition Mode. See GitHub issue #1752.
+if ($action == "print") $table_assign_judge = table_assignments($_SESSION['user_id'],"J",$_SESSION['prefsTimeZone'],$_SESSION['prefsDateFormat'],$_SESSION['prefsTimeFormat'],1);
+else $table_assign_judge = table_assignments($_SESSION['user_id'],"J",$_SESSION['prefsTimeZone'],$_SESSION['prefsDateFormat'],$_SESSION['prefsTimeFormat'],0);
+if ($action == "print") $table_assign_steward = table_assignments($_SESSION['user_id'],"S",$_SESSION['prefsTimeZone'],$_SESSION['prefsDateFormat'],$_SESSION['prefsTimeFormat'],1);
+else $table_assign_steward = table_assignments($_SESSION['user_id'],"S",$_SESSION['prefsTimeZone'],$_SESSION['prefsDateFormat'],$_SESSION['prefsTimeFormat'],0);
+
+// Coordinator/organizer mailto links for the "already assigned" guidance, falling back to
+// the contact page when contacts are not published.
+$coordinator_links = "";
+if ((!empty($table_assign_judge)) || (!empty($table_assign_steward))) {
+	$coordinator_links = coordinator_mailto_links($db_conn, $prefix);
+	if (empty($coordinator_links)) $coordinator_links = sprintf("<a href=\"%s\">%s</a>",build_public_url("contact","default","default","default",$sef,$base_url),$label_contact);
 }
 
 /**
@@ -592,7 +601,10 @@ if ($show_judge_steward_fields) {
 				}
 			}
 
-			if (!empty($table_assign_judge)) $account_display .= sprintf("<p><strong class=\"text-success\">%s %s.</strong></p><p>%s</p>",$brewer_info_008,$label_judge,$brewer_info_009);
+			if (!empty($table_assign_judge)) {
+				$account_display .= sprintf("<p><strong class=\"text-success\">%s %s.</strong></p><p>%s</p>",$brewer_info_008,$label_judge,$brewer_info_009);
+				if (!empty($coordinator_links)) $account_display .= sprintf("<p>%s</p>",$coordinator_links);
+			}
 			elseif ((in_array("Steward",$assignment_array)) && (!empty($assignment))) $account_display .= sprintf("%s %s.",$brewer_info_010,$label_steward);
 			$account_display .= "</div>";
 			$account_display .= "</div>";
@@ -666,7 +678,10 @@ if ($show_judge_steward_fields) {
 
 				else $account_display .= "";
 			}
-			if ((!empty($table_assign_steward)) && (!empty($assignment))) $account_display .= sprintf("<p><strong class=\"text-success\">You have already been assigned as a %s to a table</strong>.</p><p>If you wish to change your availabilty and/or withdraw your role, <a href=\"%s\">contact</a> the competition organizer or judge coordinator.</p>",$assignment,build_public_url("contact","default","default","default",$sef,$base_url));
+			if ((!empty($table_assign_steward)) && (!empty($assignment))) {
+				$account_display .= sprintf("<p><strong class=\"text-success\">%s %s.</strong></p><p>%s</p>",$brewer_info_008,$label_steward,$brewer_info_009);
+				if (!empty($coordinator_links)) $account_display .= sprintf("<p>%s</p>",$coordinator_links);
+			}
 			elseif ((in_array("Judge",$assignment_array)) && (!empty($assignment))) $account_display .= sprintf("You have already been assigned as a %s.",$assignment);
 			$account_display .= "</div>";
 			$account_display .= "</div>";

--- a/sections/brewer_info.sec.php
+++ b/sections/brewer_info.sec.php
@@ -243,11 +243,20 @@ foreach ($a as $value) {
 
 }
 
-if ($_SESSION['jPrefsTablePlanning'] == 0) {
-	if ($action == "print") $table_assign_judge = table_assignments($_SESSION['user_id'],"J",$_SESSION['prefsTimeZone'],$_SESSION['prefsDateFormat'],$_SESSION['prefsTimeFormat'],1);
-	else $table_assign_judge = table_assignments($_SESSION['user_id'],"J",$_SESSION['prefsTimeZone'],$_SESSION['prefsDateFormat'],$_SESSION['prefsTimeFormat'],0);
-	if ($action == "print") $table_assign_steward = table_assignments($_SESSION['user_id'],"S",$_SESSION['prefsTimeZone'],$_SESSION['prefsDateFormat'],$_SESSION['prefsTimeFormat'],1);
-	else $table_assign_steward = table_assignments($_SESSION['user_id'],"S",$_SESSION['prefsTimeZone'],$_SESSION['prefsDateFormat'],$_SESSION['prefsTimeFormat'],0);
+// Resolve table assignments in both Tables Planning and Competition Mode so an assigned
+// participant can see why their judge/steward fields are locked. This previously ran only
+// in Competition Mode. See GitHub issue #1752.
+if ($action == "print") $table_assign_judge = table_assignments($_SESSION['user_id'],"J",$_SESSION['prefsTimeZone'],$_SESSION['prefsDateFormat'],$_SESSION['prefsTimeFormat'],1);
+else $table_assign_judge = table_assignments($_SESSION['user_id'],"J",$_SESSION['prefsTimeZone'],$_SESSION['prefsDateFormat'],$_SESSION['prefsTimeFormat'],0);
+if ($action == "print") $table_assign_steward = table_assignments($_SESSION['user_id'],"S",$_SESSION['prefsTimeZone'],$_SESSION['prefsDateFormat'],$_SESSION['prefsTimeFormat'],1);
+else $table_assign_steward = table_assignments($_SESSION['user_id'],"S",$_SESSION['prefsTimeZone'],$_SESSION['prefsDateFormat'],$_SESSION['prefsTimeFormat'],0);
+
+// Coordinator/organizer mailto links for the "already assigned" guidance, falling back to
+// the contact page when contacts are not published.
+$coordinator_links = "";
+if ((!empty($table_assign_judge)) || (!empty($table_assign_steward))) {
+	$coordinator_links = coordinator_mailto_links($db_conn, $prefix);
+	if (empty($coordinator_links)) $coordinator_links = sprintf("<a href=\"%s\">%s</a>",build_public_url("contact","default","default","default",$sef,$base_url,"default"),$label_contact);
 }
 
 if ($_SESSION['brewerJudgeLikes'] != "") {
@@ -556,7 +565,10 @@ if ($show_judge_steward_fields) {
 				}
 			}
 
-			if (!empty($table_assign_judge)) $account_display .= sprintf("<p><strong class=\"text-success\">%s %s.</strong></p><p>%s</p>",$brewer_info_008,$label_judge,$brewer_info_009);
+			if (!empty($table_assign_judge)) {
+				$account_display .= sprintf("<p><strong class=\"text-success\">%s %s.</strong></p><p>%s</p>",$brewer_info_008,$label_judge,$brewer_info_009);
+				if (!empty($coordinator_links)) $account_display .= sprintf("<p>%s</p>",$coordinator_links);
+			}
 			elseif ((in_array("Steward",$assignment_array)) && (!empty($assignment))) $account_display .= sprintf("%s %s.",$brewer_info_010,$label_steward);
 			$account_display .= "</div>";
 			$account_display .= "</div>";
@@ -630,7 +642,10 @@ if ($show_judge_steward_fields) {
 
 				else $account_display .= "";
 			}
-			if ((!empty($table_assign_steward)) && (!empty($assignment))) $account_display .= sprintf("<p><strong class=\"text-success\">You have already been assigned as a %s to a table</strong>.</p><p>If you wish to change your availabilty and/or withdraw your role, <a href=\"%s\">contact</a> the competition organizer or judge coordinator.</p>",$assignment,build_public_url("contact","default","default","default",$sef,$base_url,"default"));
+			if ((!empty($table_assign_steward)) && (!empty($assignment))) {
+				$account_display .= sprintf("<p><strong class=\"text-success\">%s %s.</strong></p><p>%s</p>",$brewer_info_008,$label_steward,$brewer_info_009);
+				if (!empty($coordinator_links)) $account_display .= sprintf("<p>%s</p>",$coordinator_links);
+			}
 			elseif ((in_array("Judge",$assignment_array)) && (!empty($assignment))) $account_display .= sprintf("You have already been assigned as a %s.",$assignment);
 			$account_display .= "</div>";
 			$account_display .= "</div>";


### PR DESCRIPTION
Adds the coordinator/organizer contact links requested in the follow-up comment on #1752.

A participant who is assigned to a table cannot change their own judge/steward role, so the My Account page told them to contact the competition organizer or judge coordinator without giving them a way to reach either.

- New `coordinator_mailto_links()` builds `mailto:` links for the contacts whose `contactPosition` names a coordinator or organizer. Addresses are only published when the contact form is disabled and the contact list is shown (`prefsContact == "N"`) - the same condition under which the Contact page already publishes them. Otherwise the guidance falls back to a link to the contact page, so no address is exposed when the form is enabled or contacts are hidden.
- Wired into both the judge and steward "already assigned" messages, in the public (`pub/`) and legacy (`sections/`) themes. The steward message previously hardcoded its wording; it now uses the same `$brewer_info_008` / `$brewer_info_009` strings as the judge message.
- Table assignments now resolve in both Tables Planning and Competition Mode, so the guidance (and the links) appear in Planning Mode too. This block previously ran only in Competition Mode, which meant nothing explained the locked judge/steward fields in the exact mode where the report originated.

Roles are not stored in their own column, so contacts are matched on the free-text `contactPosition` (case-insensitive "coordinator" / "organizer" / "organiser"). Happy to move to explicit role columns if that would be preferred.

Verification: `php -l` clean on all three files; PHPStan (level 0, project config) reports an identical result on the changed files before and after the change. I could not exercise these pages live (no database or `site/config.php` in my checkout), so this is code- and schema-level verification only.
